### PR TITLE
[Reviewer: Mike] Correct handling of exceptional events

### DIFF
--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -781,8 +781,7 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
                 queue[processed].key = h;
                 queue[processed].event_type = EXCEPTION_EVENT;
                 ++processed;
-            } else if (!(events[i].events & EPOLLERR) &&
-                       (key_has_pending_read(h) || key_has_pending_accept(h))) {
+            } else if (key_has_pending_read(h) || key_has_pending_accept(h)) {
 #if PJ_IOQUEUE_HAS_SAFE_UNREG
                 increment_counter(h);
 #endif


### PR DESCRIPTION
Mike, I've found an issue with the fix to bug128 - we were checking a condition that couldn't possibly be true (!(events[i].events & EPOLLERR)) because the containing block was only entered if the opposite was true.  The condition should read (!(events[i].events & EPOLLIN)) but this is now superfluous because if that condition were true we would have entered a previous branch and then done a "continue" to skip over the rest of the block.  As a result, I've simply removed this check.  I've tested this while running stress and not seen the same ioqueue hangs that I saw before.
