### PR TITLE
[Reviewer Andy] Change to use soft asserts in PJSIP

### DIFF
--- a/pjlib/include/pj/config_site.h
+++ b/pjlib/include/pj/config_site.h
@@ -72,3 +72,16 @@
  */
 #define PJSIP_POOL_LEN_ENDPT 20000000
 #define PJSIP_POOL_INC_ENDPT 10000000
+/**
+ * Move to soft assert behaviour rather than hard asserts.
+ */
+extern int pj_log_get_level(void);
+extern void pj_log_1(const char *src, const char *format, ...);
+#define pj_assert(expr) \
+          if (!(expr)) { \
+              if (pj_log_get_level() >= 1) { \
+                  pj_log_1("Assert failed:", "%s:%d %s", \
+                           __FILE__, __LINE__, #expr); \
+              } \
+          }
+


### PR DESCRIPTION
Andy

Can you review this change to PJSIP config_site file to change to use soft asserts.  I've tested by hacking in a failing pj_assert to sprout's start-up code immediately after the call to pj_init(), where I get the following output, proving that it carried on after the assert.

Mike

```
25-10-2013 21:24:23.648 Error pjsip: Assert failed: stack.cpp:593 status == PJ_SUCCESS
25-10-2013 21:24:23.824 Status stack.cpp:513: Listening on port 5054
25-10-2013 21:24:23.824 Status stack.cpp:773: Local host aliases:
25-10-2013 21:24:23.824 Status stack.cpp:778:  10.144.9.222
25-10-2013 21:24:23.824 Status stack.cpp:778:  sprout.me3.cw-ngv.com
25-10-2013 21:24:23.824 Status stack.cpp:778:  10.144.9.222
25-10-2013 21:24:23.824 Status stack.cpp:778:  sprout.me3.cw-ngv.com
```
