### PR TITLE
[Reviewer Matt] Fix to sprout issue 138, hung UAC transaction if transport fails when transaction is already terminated

### DIFF
--- a/pjsip/src/pjsip/sip_transaction.c
+++ b/pjsip/src/pjsip/sip_transaction.c
@@ -1976,7 +1976,9 @@ static void tsx_tp_state_callback( pjsip_transport *tp,
 
 	tsx = (pjsip_transaction*)info->user_data;
 
-	/* Ignore the event if the transaction has already terminated. */
+	/* Ignore the event if the transaction has already terminated,
+	 * otherwise the transition to destroyed state won't happen.
+	 */
 	if (tsx->state < PJSIP_TSX_STATE_TERMINATED) {
 	    /* Post the event for later processing, to avoid deadlock.
 	     * See https://trac.pjsip.org/repos/ticket/1646


### PR DESCRIPTION
Matt

Could you review my fix to the PJSIP issue I found yesterday.  See https://github.com/Metaswitch/sprout/issues/318 for details of the issue.  I've tested the fix with the BasicProxy UT test case that originally found the issue, and verified that it doesn't break any of the other UTs.

Mike
