### PR TITLE
[Reviewer: Mike][From: Alex] Don't unquote unknown digest parameters in WWW-Authenticate headers.

### DIFF
--- a/pjsip/src/pjsip/sip_auth_parser.c
+++ b/pjsip/src/pjsip/sip_auth_parser.c
@@ -149,9 +149,6 @@ static void parse_digest_challenge( pj_scanner *scanner, pj_pool_t *pool,
 	    unquoted_value.slen = value.slen;
 	}
 
-	pjsip_parse_param_imp(scanner, pool, &name, &value,
-			      PJSIP_PARSE_REMOVE_QUOTE);
-
 	if (!pj_stricmp(&name, &pjsip_REALM_STR)) {
 	    chal->realm = unquoted_value;
 


### PR DESCRIPTION
Mike, please can you review my fix to make PJSIP not remove quotes around digest parameters when proxying a WWW-Authenticate header. Should be self explanatory. 

I've tested this with a new sprout UT. All existing UTs pass as well obviously :-).

Thanks,
Alex.
