### PR TITLE
Reviewer Rob - Increase custom headers count

### DIFF
--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -820,7 +820,7 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 #define PJSIP_POOL_INC_DIALOG		512
 
 /* Maximum header types. */
-#define PJSIP_MAX_HEADER_TYPES		72
+#define PJSIP_MAX_HEADER_TYPES		128
 
 /* Maximum URI types. */
 #define PJSIP_MAX_URI_TYPES		4


### PR DESCRIPTION
The contact filtering feature adds 4 new header definitions, which puts us at just over the maximum number of headers in pjSIP.  This change simply expands the space to a nice round power of 2 to give us room.
