### PR TITLE
[Reviewer Matt] Don't print existing Content-Length header if adding a new one

### DIFF
--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -471,6 +471,17 @@ PJ_DEF(pj_ssize_t) pjsip_msg_print( const pjsip_msg *msg,
             continue;
         }
 
+        if (hdr->type == PJSIP_H_CONTENT_TYPE &&
+            msg->body &&
+            msg->body->content_type.type.slen != 0) {
+            /* If there is a message body with content-type specified then
+             * Content-Type header is added automatically, so ignore the 
+             * existing header.  (Note that it is legitimate to have a
+             * Content-Type header with no body - see RFC3261 20.15.)
+             */
+            continue;
+        }
+
 	len = pjsip_hdr_print_on(hdr, p, end-p);
 	if (len < 0)
 	    return -1;


### PR DESCRIPTION
Matt

Can you review this fix for me - PJSIP was adding extra Content-Length headers when transmitting messages, so after a sequence of forwarding a message to various places we could end up with several Content-Length headers.  This fixes sprout issue https://github.com/Metaswitch/sprout/issues/706.

I've tested by running some UTs and manually inspecting the results.

Mike
