### PR TITLE
[Reviewer Graeme] Don't switch to TCP transport if application has already selected transport

### DIFF
--- a/pjsip/src/pjsip/sip_util.c
+++ b/pjsip/src/pjsip/sip_util.c
@@ -1300,9 +1300,13 @@ stateless_send_resolver_callback( pj_status_t status,
 	    return;
 	}
 
-	/* Check if request message is larger than 1300 bytes. */
+	/* Check if request message is larger than 1300 bytes, but only if
+         * the application hasn't already selected a transport for the
+         * request.
+         */
 	len = tdata->buf.cur - tdata->buf.start;
-	if (len >= PJSIP_UDP_SIZE_THRESHOLD) {
+	if (len >= PJSIP_UDP_SIZE_THRESHOLD &&
+            tdata->tp_sel.type != PJSIP_TPSELECTOR_TRANSPORT) {
 	    int i;
 	    int count = tdata->dest_info.addr.count;
 


### PR DESCRIPTION
Can you review my fix to the large ACK issue (https://github.com/Metaswitch/sprout/issues/728).  As per the discussion in the issue, I've taken the approach of disabling switching to TCP in this case, on the grounds that the switch will almost certainly fail anyway.  I've tested by manually hacking one of the live tests to include a large message body on an ACK.  I've also got some UTs in Sprout which I'll release in a sprout pull request when this has been merged.

Mike
