### PR TITLE
[Reviewer: Mike] Don't allow quotes in usernames in URIs

### DIFF
--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -443,10 +443,9 @@ static pj_status_t init_parser()
     PJ_ASSERT_RETURN(status == PJ_SUCCESS, status);
     pj_cis_del_str( &pconst.pjsip_PASSWD_SPEC_ESC, ESCAPED);
 
-    status = pj_cis_init(&cis_buf, &pconst.pjsip_PROBE_USER_HOST_SPEC);
+    status = pj_cis_dup(&pconst.pjsip_PROBE_USER_HOST_SPEC, &pconst.pjsip_ALNUM_SPEC);
     PJ_ASSERT_RETURN(status == PJ_SUCCESS, status);
-    pj_cis_add_str( &pconst.pjsip_PROBE_USER_HOST_SPEC, UNRESERVED ESCAPED USER_UNRESERVED);
-    pj_cis_invert( &pconst.pjsip_PROBE_USER_HOST_SPEC );
+    pj_cis_add_str( &pconst.pjsip_PROBE_USER_HOST_SPEC, UNRESERVED ESCAPED USER_UNRESERVED ":");
 
     status = pj_cis_init(&cis_buf, &pconst.pjsip_DISPLAY_SPEC);
     PJ_ASSERT_RETURN(status == PJ_SUCCESS, status);


### PR DESCRIPTION
Mike, please could you review this simple fix to make PJSIP not allow quotes in usernames (they are forbidden according to the BNF in RFC 3261). 

Without this fix we have problems parsing URIs like: `sip:scscf.example.com;some-param="bob@example.com"`. PJSIP scans forward in the URI looking for the first character that is not valid in a username. It finds `@` and assumes the URI has a username. This fix means that PJSIP will stop when it gets to the `"`, and because this isn't an `@`, treats the URI as if it does not have a username (the correct behavior). 
