### PR TITLE
[Reviewer: Mike] Only strip [] from IPv6 addresses if PJSIP_PARSE_REMOVE_QUOTE is set.

### DIFF
--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -1222,9 +1222,11 @@ static void parse_param_imp( pj_scanner *scanner, pj_pool_t *pool,
 		 * '[' and ']' quote characters are to be removed
 		 * from the pvalue.
 		 */
-		pj_scan_get_char(scanner);
-		pj_scan_get_until_ch(scanner, ']', pvalue);
-		pj_scan_get_char(scanner);
+		pj_scan_get_quote( scanner, '[', ']', pvalue);
+		if (option & PJSIP_PARSE_REMOVE_QUOTE) {
+		    pvalue->ptr++;
+		    pvalue->slen -= 2;
+		}
 	    } else if(pj_cis_match(spec, *scanner->curptr)) {
 		parser_get_and_unescape(scanner, pool, spec, esc_spec, pvalue);
 	    }


### PR DESCRIPTION
In conjunction with https://github.com/Metaswitch/sprout/tree/ipv6_pcfa, this fixes https://github.com/Metaswitch/sprout/issues/611.

I wasn't sure whether to reuse PJSIP_PARSE_REMOVE_QUOTE or create a new option - I decided to reuse it because the meaning is really the same, "I want exactly what the SIP message said and am happy to do some extra parsing to make that work". The comment also refers to this as a "quoted IPv6 address", so I think it will make sense to the PJSIP maintainers too.
