### PR TITLE
[Reviewer: Alex] Add configurable SIP send timeout

### DIFF
--- a/pjlib/include/pj/compat/socket.h
+++ b/pjlib/include/pj/compat/socket.h
@@ -107,6 +107,10 @@
 #if defined(PJ_HAS_NETINET_TCP_H) && PJ_HAS_NETINET_TCP_H != 0
 /* To pull in TCP_NODELAY constants */
 #  include <netinet/tcp.h>
+/* Define TCP_USER_TIMEOUT if tcp.h didn't */
+#  ifndef TCP_USER_TIMEOUT
+#    define TCP_USER_TIMEOUT 18
+#  endif
 #endif
 
 #if defined(PJ_HAS_NET_IF_H) && PJ_HAS_NET_IF_H != 0

--- a/pjlib/include/pj/sock.h
+++ b/pjlib/include/pj/sock.h
@@ -293,6 +293,11 @@ extern const pj_uint16_t PJ_SO_SNDBUF;
 /** Disables the Nagle algorithm for send coalescing. @see pj_TCP_NODELAY */
 extern const pj_uint16_t PJ_TCP_NODELAY;
 
+/** Maximum amount of time in milliseconds that transmitted data may remain
+ *  unacknowledged before TCP will forcibly close the connection.
+ *  @see pj_TCP_USER_TIMEOUT */
+extern const pj_uint16_t PJ_TCP_USER_TIMEOUT;
+
 /** Allows the socket to be bound to an address that is already in use.
  *  @see pj_SO_REUSEADDR */
 extern const pj_uint16_t PJ_SO_REUSEADDR;
@@ -333,6 +338,9 @@ extern const pj_uint16_t PJ_IP_DROP_MEMBERSHIP;
     /** Get #PJ_TCP_NODELAY constant */
     PJ_DECL(pj_uint16_t) pj_TCP_NODELAY(void);
 
+    /** Get #PJ_TCP_USER_TIMEOUT constant */
+    PJ_DECL(pj_uint16_t) pj_TCP_USER_TIMEOUT(void);
+
     /** Get #PJ_SO_REUSEADDR constant */
     PJ_DECL(pj_uint16_t) pj_SO_REUSEADDR(void);
 
@@ -368,6 +376,9 @@ extern const pj_uint16_t PJ_IP_DROP_MEMBERSHIP;
 
     /** Get #PJ_TCP_NODELAY constant */
 #   define pj_TCP_NODELAY() PJ_TCP_NODELAY
+
+    /** Get #PJ_TCP_USER_TIMEOUT constant */
+#   define pj_TCP_USER_TIMEOUT() PJ_TCP_USER_TIMEOUT
 
     /** Get #PJ_SO_REUSEADDR constant */
 #   define pj_SO_REUSEADDR() PJ_SO_REUSEADDR

--- a/pjlib/src/pj/sock_bsd.c
+++ b/pjlib/src/pj/sock_bsd.c
@@ -136,6 +136,7 @@ const pj_uint16_t PJ_SO_TYPE    = SO_TYPE;
 const pj_uint16_t PJ_SO_RCVBUF  = SO_RCVBUF;
 const pj_uint16_t PJ_SO_SNDBUF  = SO_SNDBUF;
 const pj_uint16_t PJ_TCP_NODELAY= TCP_NODELAY;
+const pj_uint16_t PJ_TCP_USER_TIMEOUT= TCP_USER_TIMEOUT;
 const pj_uint16_t PJ_SO_REUSEADDR= SO_REUSEADDR;
 #ifdef SO_NOSIGPIPE
 const pj_uint16_t PJ_SO_NOSIGPIPE = SO_NOSIGPIPE;

--- a/pjlib/src/pj/sock_common.c
+++ b/pjlib/src/pj/sock_common.c
@@ -1202,6 +1202,11 @@ PJ_DEF(pj_uint16_t) pj_TCP_NODELAY(void)
     return PJ_TCP_NODELAY;
 }
 
+PJ_DEF(pj_uint16_t) pj_TCP_USER_TIMEOUT(void)
+{
+    return PJ_TCP_USER_TIMEOUT;
+}
+
 PJ_DEF(pj_uint16_t) pj_SO_REUSEADDR(void)
 {
     return PJ_SO_REUSEADDR;

--- a/pjsip/include/pjsip/sip_config.h
+++ b/pjsip/include/pjsip/sip_config.h
@@ -590,6 +590,18 @@ PJ_INLINE(pjsip_cfg_t*) pjsip_cfg(void)
 
 
 /**
+ * The send timeout for TCP transports.  If it takes longer than this
+ * for data to be acknowledged by the peer, the connection will be torn
+ * down.  If the value is zero, the OS default will be used.
+ *
+ * Default: 0 (milliseconds) - use OS default
+ */
+#ifndef PJSIP_TCP_SEND_TIMEOUT_MS
+#   define PJSIP_TCP_SEND_TIMEOUT_MS     0
+#endif
+
+
+/**
  * Set the interval to send keep-alive packet for TCP transports.
  * If the value is zero, keep-alive will be disabled for TCP.
  *

--- a/pjsip/include/pjsip/sip_transport_tcp.h
+++ b/pjsip/include/pjsip/sip_transport_tcp.h
@@ -107,6 +107,15 @@ typedef struct pjsip_tcp_transport_cfg
      */
     unsigned            connect_timeout_ms;
 
+    /**
+     * The send timeout (ms) for TCP transports.  If it takes longer than
+     * this for data to be acknowledged by the peer, the connection will be
+     * torn down.  If the value is zero, the OS default will be used.
+     *
+     * Default: PJSIP_TCP_SEND_TIMEOUT_MS
+     */
+    unsigned            send_timeout_ms;
+
 } pjsip_tcp_transport_cfg;
 
 


### PR DESCRIPTION
Alex,

Please can you review this enhancement to add a configurable SIP send timeout?  It's basically just plumbing through to the `setsockopt` call.

Thanks,

Matt