### PR TITLE
[Reviewer: Alex] Avoid generating invalid digest credentials

### DIFF
--- a/pjsip/src/pjsip/sip_auth_msg.c
+++ b/pjsip/src/pjsip/sip_auth_msg.c
@@ -70,7 +70,10 @@ static int print_digest_credential(pjsip_digest_credential *cred, char *buf, pj_
     char *endbuf = buf + size;
     const pjsip_parser_const_t *pc = pjsip_parser_const();
     
+    // Print the first parameter unconditionally, to avoid printing an invalid header with a leading
+    // comma (e.g.  'Authorization: Digest , username=x').
     copy_advance_pair_quote(buf, "response=", 9, cred->response, '"', '"');
+    
     copy_advance_pair_quote_cond(buf, ", username=", 11, cred->username, '"', '"');
     copy_advance_pair_quote_cond(buf, ", realm=", 8, cred->realm, '"', '"');
     copy_advance_pair_quote(buf, ", nonce=", 8, cred->nonce, '"', '"');

--- a/pjsip/src/pjsip/sip_auth_msg.c
+++ b/pjsip/src/pjsip/sip_auth_msg.c
@@ -70,11 +70,11 @@ static int print_digest_credential(pjsip_digest_credential *cred, char *buf, pj_
     char *endbuf = buf + size;
     const pjsip_parser_const_t *pc = pjsip_parser_const();
     
-    copy_advance_pair_quote_cond(buf, "username=", 9, cred->username, '"', '"');
+    copy_advance_pair_quote(buf, "response=", 9, cred->response, '"', '"');
+    copy_advance_pair_quote_cond(buf, ", username=", 11, cred->username, '"', '"');
     copy_advance_pair_quote_cond(buf, ", realm=", 8, cred->realm, '"', '"');
     copy_advance_pair_quote(buf, ", nonce=", 8, cred->nonce, '"', '"');
     copy_advance_pair_quote_cond(buf, ", uri=", 6, cred->uri, '"', '"');
-    copy_advance_pair_quote(buf, ", response=", 11, cred->response, '"', '"');
     copy_advance_pair(buf, ", algorithm=", 12, cred->algorithm);
     copy_advance_pair_quote_cond(buf, ", cnonce=", 9, cred->cnonce, '"', '"');
     copy_advance_pair_quote_cond(buf, ", opaque=", 9, cred->opaque, '"', '"');


### PR DESCRIPTION
Previously, if no username was specified, the Authorization header was invalid - it had a comma between "Digest" and the first parameter.

This just re-orders it, so that the 'response' parameter (always unconditionally printed) comes first. Tested live.