### PR TITLE
[Reviewer: Rob] Drop support for PJSIP-proprietary "hide" parameter

### DIFF
--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -1826,22 +1826,6 @@ static int pjsip_routing_hdr_print( pjsip_routing_hdr *hdr,
     pjsip_sip_uri *sip_uri;
     pjsip_param *p;
 
-    /* Check the proprietary param 'hide', don't print this header
-     * if it exists in the route URI.
-     */
-    sip_uri = (pjsip_sip_uri*) pjsip_uri_get_uri(hdr->name_addr.uri);
-    p = sip_uri->other_param.next;
-    while (p != &sip_uri->other_param) {
-	const pj_str_t st_hide = {"hide", 4};
-
-	if (pj_stricmp(&p->name, &st_hide) == 0) {
-	    /* Check if param 'hide' is specified without 'lr'. */
-	    pj_assert(sip_uri->lr_param != 0);
-	    return 0;
-	}
-	p = p->next;
-    }
-
     /* Route and Record-Route don't compact forms */
 
     copy_advance(buf, hdr->name);


### PR DESCRIPTION
Rob,

Please can you review this fix to https://github.com/Metaswitch/sprout/issues/1170 to drop the support for the PJSIP-proprietary "hide" parameter?  I've UT-ed in the sprout codebase (which will follow shortly).

Thanks,

matt