### PR TITLE
[Reviewer: Alex] Fixes for clang interop

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -3526,7 +3526,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 if test -z "$CROSS_COMPILE"; then
-    CROSS_COMPILE=`echo ${CC} | sed 's/gcc//'`
+    CROSS_COMPILE=`echo ${CC} | sed 's/gcc//' | sed 's/clang-3\..//' | sed 's/clang//'`
 fi
 
 if test "$AR" = ""; then AR="${CROSS_COMPILE}ar rv"; fi

--- a/third_party/srtp/crypto/cipher/aes_icm.c
+++ b/third_party/srtp/crypto/cipher/aes_icm.c
@@ -283,7 +283,7 @@ aes_icm_set_iv(aes_icm_ctx_t *c, void *iv) {
  * this is an internal, hopefully inlined function
  */
   
-inline void
+static inline void
 aes_icm_advance_ismacryp(aes_icm_ctx_t *c, uint8_t forIsmacryp) {
   /* fill buffer with new keystream */
   v128_copy(&c->keystream_buffer, &c->counter);

--- a/third_party/srtp/crypto/math/datatypes.c
+++ b/third_party/srtp/crypto/math/datatypes.c
@@ -124,7 +124,7 @@ octet_string_hex_string(const void *s, int length) {
   return bit_string;
 }
 
-inline int
+static inline int
 hex_char_to_nibble(uint8_t c) {
   switch(c) {
   case ('0'): return 0x0;


### PR DESCRIPTION
(I've started compiling with clang - it's faster and gives more warnings - so I'm fixing up the issues that come out of the woodwork.)

This gets PJSIP building with clang - one is the fix mentioned in https://freeswitch.org/jira/si/jira.issueviews:issue-html/FS-6196/FS-6196.html, the other just updates a line of code which filters "gcc" out to also filter "clang" and "clang-3.6".