### PR TITLE
[Reviewer AMC] Handle missing content-length header in TCP packets

### DIFF
--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1657,7 +1657,7 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
         	    /* No content-length header which is not allowed. */
         	    PJ_LOG(2,(THIS_FILE, 
                               "No content-length header in TCP packet"));
-        	    return -1;
+        	    return -PJSIP_EMISSINGHDR;
 		} else {
 		    /* Not enough data in packet. */
 		    return total_processed;

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1653,6 +1653,9 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
 		    mgr->on_rx_msg(mgr->endpt, PJSIP_ERXOVERFLOW, rdata);
 		    /* Exhaust all data. */
 		    return rdata->pkt_info.len;
+    } else if (msg_status == PJSIP_EMISSINGHDR) {
+        /* No content-length header which is not allowed. Return error here. */
+        return -1;
 		} else {
 		    /* Not enough data in packet. */
 		    return total_processed;

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1653,11 +1653,11 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
 		    mgr->on_rx_msg(mgr->endpt, PJSIP_ERXOVERFLOW, rdata);
 		    /* Exhaust all data. */
 		    return rdata->pkt_info.len;
-    } else if (msg_status == PJSIP_EMISSINGHDR) {
-        /* No content-length header which is not allowed. Return error here. */
-        /*                                                                   */
-        PJ_LOG(2,(THIS_FILE, "No content-length header in TCP packet"));
-        return -1;
+     		} else if (msg_status == PJSIP_EMISSINGHDR) {
+        	    /* No content-length header which is not allowed. */
+        	    PJ_LOG(2,(THIS_FILE, 
+                              "No content-length header in TCP packet"));
+        	    return -1;
 		} else {
 		    /* Not enough data in packet. */
 		    return total_processed;

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1654,10 +1654,15 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
 		    /* Exhaust all data. */
 		    return rdata->pkt_info.len;
      		} else if (msg_status == PJSIP_EMISSINGHDR) {
-        	    /* No content-length header which is not allowed. */
-        	    PJ_LOG(2,(THIS_FILE, 
+                    /* pjsip_find_msg will only return this if it has received 
+                     * the blank line denoting end of headers but cannot find a
+                     * Content-Length header.
+                     *
+                     * This is not allowed for TCP according to RFC3261 (20.14)
+                     */
+                    PJ_LOG(3,(THIS_FILE, 
                               "No content-length header in TCP packet"));
-        	    return -PJSIP_EMISSINGHDR;
+                    return -PJSIP_EMISSINGHDR;
 		} else {
 		    /* Not enough data in packet. */
 		    return total_processed;

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1655,6 +1655,8 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
 		    return rdata->pkt_info.len;
     } else if (msg_status == PJSIP_EMISSINGHDR) {
         /* No content-length header which is not allowed. Return error here. */
+        /*                                                                   */
+        PJ_LOG(2,(THIS_FILE, "No content-length header in TCP packet"));
         return -1;
 		} else {
 		    /* Not enough data in packet. */

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1396,17 +1396,18 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
             pjsip_tpmgr_receive_packet(rdata->tp_info.transport->tpmgr,
                                        rdata);
 
-        pj_assert(size_eaten <= (pj_size_t)rdata->pkt_info.len);
 
         if (size_eaten == -1) {
           /* There was a problem receiving the message.  This suggests the
            * data on the socket is corrupt.  Shutdown this connection.
            */
-          PJ_LOG(2,(tcp->base.obj_name, "Reeive failed, closing connection"));
+          PJ_LOG(2,(tcp->base.obj_name, "Receive failed, closing connection"));
 
           tcp_init_shutdown(tcp, PJSIP_EINVALIDMSG);
           return PJ_FALSE;
         }
+
+        pj_assert(size_eaten <= (pj_size_t)rdata->pkt_info.len);
 
         /* Handle unprocessed data. */
         *remainder = rdata->pkt_info.len - size_eaten;

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1401,8 +1401,8 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
            * data on the socket is corrupt.  Shutdown this connection.
            */
           PJ_LOG(2,(THIS_FILE, 
-                    tcp->base.obj_name, 
-                    "Receive failed, closing TCP connection"));
+                    "Receive failed, closing TCP connection: %s",
+                    tcp->base.obj_name));
 
           tcp_init_shutdown(tcp, PJSIP_EINVALIDMSG);
           return PJ_FALSE;

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1398,6 +1398,16 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
 
         pj_assert(size_eaten <= (pj_size_t)rdata->pkt_info.len);
 
+        if (size_eaten == -1) {
+          /* There was a problem receiving the message.  This suggests the
+           * data on the socket is corrupt.  Shutdown this connection.
+           */
+          PJ_LOG(2,(tcp->base.obj_name, "Reeive failed, closing connection"));
+
+          tcp_init_shutdown(tcp, PJSIP_EINVALIDMSG);
+          return PJ_FALSE;
+        }
+
         /* Handle unprocessed data. */
         *remainder = rdata->pkt_info.len - size_eaten;
         if (*remainder < PJSIP_NORMAL_PKT_LEN) {

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1361,7 +1361,7 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
      * to be parsed.
      */
     if (status == PJ_SUCCESS) {
-	pj_size_t size_eaten;
+	pj_ssize_t size_eaten;
 
 	/* Mark this as an activity */
 	pj_gettimeofday(&tcp->last_activity);
@@ -1409,7 +1409,7 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
           return PJ_FALSE;
         }
 
-        pj_assert(size_eaten <= (pj_size_t)rdata->pkt_info.len);
+        pj_assert(size_eaten <= (pj_ssize_t)rdata->pkt_info.len);
 
         /* Handle unprocessed data. */
         *remainder = rdata->pkt_info.len - size_eaten;

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1396,12 +1396,13 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
             pjsip_tpmgr_receive_packet(rdata->tp_info.transport->tpmgr,
                                        rdata);
 
-        if (size_eaten == -1) {
+        if (size_eaten < 0) {
           /* There was a problem receiving the message.  This suggests the
            * data on the socket is corrupt.  Shutdown this connection.
            */
           PJ_LOG(2,(THIS_FILE, 
-                    "Receive failed, closing TCP connection: %s",
+                    "Receive failed (%d), closing TCP connection: %s",
+                    size_eaten,
                     tcp->base.obj_name));
 
           tcp_init_shutdown(tcp, PJSIP_EINVALIDMSG);

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1396,12 +1396,13 @@ static pj_bool_t on_data_read(pj_activesock_t *asock,
             pjsip_tpmgr_receive_packet(rdata->tp_info.transport->tpmgr,
                                        rdata);
 
-
         if (size_eaten == -1) {
           /* There was a problem receiving the message.  This suggests the
            * data on the socket is corrupt.  Shutdown this connection.
            */
-          PJ_LOG(2,(tcp->base.obj_name, "Receive failed, closing connection"));
+          PJ_LOG(2,(THIS_FILE, 
+                    tcp->base.obj_name, 
+                    "Receive failed, closing TCP connection"));
 
           tcp_init_shutdown(tcp, PJSIP_EINVALIDMSG);
           return PJ_FALSE;


### PR DESCRIPTION
[Reviewer AMC] Handle missing content-length header in TCP packets by dropping the connection to avoid hanging that connection indefinitely.

Tested in sprout UTs and by feeding corrupt SIP in directly using sipp.  Also ran Clearwater Live Tests against the new code as sanity check.