### PR TITLE
[Reviewer: Matt] Allow concurrent writes

### DIFF
--- a/pjlib/src/pj/activesock.c
+++ b/pjlib/src/pj/activesock.c
@@ -234,6 +234,11 @@ PJ_DEF(pj_status_t) pj_activesock_create( pj_pool_t *pool,
         pj_ioqueue_set_concurrency(asock->key, opt->concurrency);
     }
 
+    if (opt && opt->concurrency >= 0) {
+        // Write concurrency is OK even for whole data
+        pj_ioqueue_set_write_only_concurrency(asock->key, opt->concurrency);
+    }
+
 #if defined(PJ_IPHONE_OS_HAS_MULTITASKING_SUPPORT) && \
     PJ_IPHONE_OS_HAS_MULTITASKING_SUPPORT!=0
     asock->sock = sock;

--- a/pjlib/src/pj/ioqueue_common_abs.c
+++ b/pjlib/src/pj/ioqueue_common_abs.c
@@ -272,7 +272,6 @@ void ioqueue_dispatch_write_event(pj_ioqueue_t *ioqueue, pj_ioqueue_key_t *h)
 	     */
 	    has_lock = PJ_FALSE;
 	    pj_ioqueue_unlock_key(h);
-      pj_assert(!"RKD - entered the unlocking branch, all is OK");
 	} else {
       pj_assert(!"RKD - should not enter this branch");
 	    has_lock = PJ_TRUE;
@@ -393,7 +392,6 @@ void ioqueue_dispatch_write_event(pj_ioqueue_t *ioqueue, pj_ioqueue_key_t *h)
 		has_lock = PJ_FALSE;
 		pj_ioqueue_unlock_key(h);
 		PJ_RACE_ME(5);
-      pj_assert(!"RKD - entered the unlocking branch, all is OK");
 	} else {
       pj_assert(!"RKD - should not enter this branch");
 		has_lock = PJ_TRUE;

--- a/pjlib/src/pj/ioqueue_common_abs.c
+++ b/pjlib/src/pj/ioqueue_common_abs.c
@@ -273,7 +273,7 @@ void ioqueue_dispatch_write_event(pj_ioqueue_t *ioqueue, pj_ioqueue_key_t *h)
 	    has_lock = PJ_FALSE;
 	    pj_ioqueue_unlock_key(h);
 	} else {
-      pj_assert(!"RKD - should not enter this branch");
+	    pj_assert(!"Clearwater requires write concurrency - should not enter this branch");
 	    has_lock = PJ_TRUE;
 	}
 
@@ -392,8 +392,8 @@ void ioqueue_dispatch_write_event(pj_ioqueue_t *ioqueue, pj_ioqueue_key_t *h)
 		has_lock = PJ_FALSE;
 		pj_ioqueue_unlock_key(h);
 		PJ_RACE_ME(5);
-	} else {
-      pj_assert(!"RKD - should not enter this branch");
+	    } else {
+		pj_assert(!"Clearwater requires write concurrency - should not enter this branch");
 		has_lock = PJ_TRUE;
 	    }
 

--- a/pjlib/src/pj/ioqueue_common_abs.h
+++ b/pjlib/src/pj/ioqueue_common_abs.h
@@ -106,6 +106,7 @@ union operation_key
     pj_bool_t		    inside_callback;	    \
     pj_bool_t		    destroy_requested;	    \
     pj_bool_t		    allow_concurrent;	    \
+    pj_bool_t		    allow_concurrent_write_only;	    \
     pj_sock_t		    fd;                     \
     int                     fd_type;                \
     void		   *user_data;              \

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -403,6 +403,8 @@ PJ_DEF(pj_status_t) pjsip_tcp_transport_start3(
 	asock_cfg.async_cnt = MAX_ASYNC_CNT;
     else
 	asock_cfg.async_cnt = cfg->async_cnt;
+	
+    asock_cfg.concurrency = 1;
 
     pj_bzero(&listener_cb, sizeof(listener_cb));
     listener_cb.on_accept_complete = &on_accept_complete;
@@ -655,6 +657,7 @@ static pj_status_t tcp_create( struct tcp_listener *listener,
     /* Create active socket */
     pj_activesock_cfg_default(&asock_cfg);
     asock_cfg.async_cnt = 1;
+    asock_cfg.concurrency = 1;
 
     pj_bzero(&tcp_callback, sizeof(tcp_callback));
     tcp_callback.on_data_read = &on_data_read;


### PR DESCRIPTION
This adds the concept of "write-only concurrency" to PJSIP, to release the transaction lock before calling the write callback (but *not* before calling the read callback) and prevent us from deadlocking if the write callback takes a transport lock. Basically as you suggested in https://github.com/Metaswitch/sprout/issues/1088.