### PR TITLE
[Reviewer: RJW2] Refactoring the parsing of generic_array_hdr to allow for non-comma delimiters.

### DIFF
--- a/pjsip/include/pjsip/sip_msg.h
+++ b/pjsip/include/pjsip/sip_msg.h
@@ -1955,12 +1955,12 @@ pjsip_warning_hdr_create_from_status( pj_pool_t *pool,
 				      pj_status_t status);
 
 /**
-* Print function for a generic array header with an arbitrary delimiter.
-* This allows the creation of array headers with custom delimiters, like
-* the semicolon-separated privacy header in RFC 3323.
-*/
-PJ_DECL(int) pjsip_generic_array_hdr_delimited_print( pjsip_generic_array_hdr *hdr,
-                      char *buf, pj_size_t size, char delimiter[], size_t delimiter_length);
+ * Print function for a generic array header with an arbitrary delimiter.
+ * This allows the creation of array headers with custom delimiters, like
+ * the semicolon-separated privacy header in RFC 3323.
+ */
+PJ_DECL(int) pjsip_delimited_array_hdr_print( pjsip_generic_array_hdr *hdr,
+                      char *buf, pj_size_t size, const pj_str_t *delimiter);
 
 /* **************************************************************************/
 /** Accept-Encoding header. */

--- a/pjsip/include/pjsip/sip_msg.h
+++ b/pjsip/include/pjsip/sip_msg.h
@@ -1954,6 +1954,14 @@ pjsip_warning_hdr_create_from_status( pj_pool_t *pool,
 				      const pj_str_t *host,
 				      pj_status_t status);
 
+/**
+* Print function for a generic array header with an arbitrary delimiter.
+* This allows the creation of array headers with custom delimiters, like
+* the semicolon-separated privacy header in RFC 3323.
+*/
+PJ_DECL(int) pjsip_generic_array_hdr_delimited_print( pjsip_generic_array_hdr *hdr,
+                      char *buf, pj_size_t size, char delimiter[], size_t delimiter_length);
+
 /* **************************************************************************/
 /** Accept-Encoding header. */
 typedef pjsip_generic_string_hdr pjsip_accept_encoding_hdr;

--- a/pjsip/include/pjsip/sip_parser.h
+++ b/pjsip/include/pjsip/sip_parser.h
@@ -327,57 +327,57 @@ PJ_DECL(pj_status_t) pjsip_parse_headers( pj_pool_t *pool, char *input,
  */
 typedef struct pjsip_parser_const_t
 {
-    const pj_str_t pjsip_USER_STR;	/**< "user" string constant.    */
-    const pj_str_t pjsip_METHOD_STR;	/**< "method" string constant   */
-    const pj_str_t pjsip_TRANSPORT_STR;	/**< "transport" string const.  */
-    const pj_str_t pjsip_MADDR_STR;	/**< "maddr" string const.	*/
-    const pj_str_t pjsip_LR_STR;	/**< "lr" string const.		*/
-    const pj_str_t pjsip_SIP_STR;	/**< "sip" string constant.	*/
-    const pj_str_t pjsip_SIPS_STR;	/**< "sips" string constant.    */
-    const pj_str_t pjsip_TEL_STR;	/**< "tel" string constant.	*/
-    const pj_str_t pjsip_BRANCH_STR;	/**< "branch" string constant.  */
-    const pj_str_t pjsip_TTL_STR;	/**< "ttl" string constant.	*/
-    const pj_str_t pjsip_RECEIVED_STR;	/**< "received" string const.   */
-    const pj_str_t pjsip_Q_STR;		/**< "q" string constant.	*/
-    const pj_str_t pjsip_EXPIRES_STR;	/**< "expires" string constant. */
-    const pj_str_t pjsip_TAG_STR;	/**< "tag" string constant.	*/
-    const pj_str_t pjsip_RPORT_STR;	/**< "rport" string const.	*/
-    const pj_str_t pjsip_INDEX_STR;	/**< "index" string constant.	*/
+    const pj_str_t pjsip_USER_STR;	         /**< "user" string constant.    */
+    const pj_str_t pjsip_METHOD_STR;	     /**< "method" string constant   */
+    const pj_str_t pjsip_TRANSPORT_STR;	     /**< "transport" string const.  */
+    const pj_str_t pjsip_MADDR_STR;	         /**< "maddr" string const.	*/
+    const pj_str_t pjsip_LR_STR;	         /**< "lr" string const.		*/
+    const pj_str_t pjsip_SIP_STR;	         /**< "sip" string constant.	*/
+    const pj_str_t pjsip_SIPS_STR;	         /**< "sips" string constant.    */
+    const pj_str_t pjsip_TEL_STR;	         /**< "tel" string constant.	*/
+    const pj_str_t pjsip_BRANCH_STR;	     /**< "branch" string constant.  */
+    const pj_str_t pjsip_TTL_STR;	         /**< "ttl" string constant.	*/
+    const pj_str_t pjsip_RECEIVED_STR;	     /**< "received" string const.   */
+    const pj_str_t pjsip_Q_STR;		         /**< "q" string constant.	*/
+    const pj_str_t pjsip_EXPIRES_STR;	     /**< "expires" string constant. */
+    const pj_str_t pjsip_TAG_STR;	         /**< "tag" string constant.	*/
+    const pj_str_t pjsip_RPORT_STR;	         /**< "rport" string const.	*/
+    const pj_str_t pjsip_INDEX_STR;	         /**< "index" string constant.	*/
 
-    pj_cis_t pjsip_HOST_SPEC;		/**< For scanning host part.	*/
-    pj_cis_t pjsip_DIGIT_SPEC;		/**< Decimal digits		*/
-    pj_cis_t pjsip_ALPHA_SPEC;		/**< Alpha (A-Z, a-z)		*/
-    pj_cis_t pjsip_ALNUM_SPEC;		/**< Decimal + Alpha.		*/
-    pj_cis_t pjsip_TOKEN_SPEC;		/**< Token.			*/
-    pj_cis_t pjsip_TOKEN_SPEC_ESC;	/**< Token without '%' character */
-    pj_cis_t pjsip_VIA_PARAM_SPEC;	/**< Via param is token + ":" for
-					     IPv6.			*/
-    pj_cis_t pjsip_VIA_PARAM_SPEC_ESC;	/**< .. as above without '%'	*/
-    pj_cis_t pjsip_HEX_SPEC;  		/**< Hexadecimal digits.	*/
-    pj_cis_t pjsip_PARAM_CHAR_SPEC;	/**< For scanning pname (or pvalue
-					     when it's  not quoted.) in URI */
-    pj_cis_t pjsip_PARAM_CHAR_SPEC_ESC;	/**< Variant without the escape ('%')
-					     char			*/
-    pj_cis_t pjsip_HDR_CHAR_SPEC;	/**< Chars in hname/havalue in URL. */
-    pj_cis_t pjsip_HDR_CHAR_SPEC_ESC;	/**< Variant without the escape ('%')
-					     char			*/
-    pj_cis_t pjsip_PROBE_USER_HOST_SPEC;/**< Hostname characters.	*/
-    pj_cis_t pjsip_PASSWD_SPEC;		/**< Password.			*/
-    pj_cis_t pjsip_PASSWD_SPEC_ESC;	/**< Variant without the escape ('%')
-					     char			*/
-    pj_cis_t pjsip_USER_SPEC;		/**< User */
-    pj_cis_t pjsip_USER_SPEC_ESC;	/**< Variant without the escape ('%')
-					     char			*/
-    pj_cis_t pjsip_USER_SPEC_LENIENT;	/**< User, with additional '#' char */
-    pj_cis_t pjsip_USER_SPEC_LENIENT_ESC;/**< pjsip_USER_SPEC_ESC with '#' */
-    pj_cis_t pjsip_NOT_NEWLINE;		/**< For eating up header, basically
-					     any chars except newlines or
-					     zero.			*/
-    pj_cis_t pjsip_NOT_COMMA_OR_NEWLINE;/**< Array elements.		*/
-    pj_cis_t pjsip_NOT_SEMICOLON_OR_NEWLINE;/**< Array elements for privacy header.       */
-    pj_cis_t pjsip_DISPLAY_SPEC;	/**< Used when searching for display
-					     name.			*/
-    pj_cis_t pjsip_OTHER_URI_CONTENT;	/**< Generic URI content.	*/
+    pj_cis_t pjsip_HOST_SPEC;		         /**< For scanning host part.	*/
+    pj_cis_t pjsip_DIGIT_SPEC;		         /**< Decimal digits		*/
+    pj_cis_t pjsip_ALPHA_SPEC;		         /**< Alpha (A-Z, a-z)		*/
+    pj_cis_t pjsip_ALNUM_SPEC;		         /**< Decimal + Alpha.		*/
+    pj_cis_t pjsip_TOKEN_SPEC;		         /**< Token.			*/
+    pj_cis_t pjsip_TOKEN_SPEC_ESC;	         /**< Token without '%' character */
+    pj_cis_t pjsip_VIA_PARAM_SPEC;	         /**< Via param is token + ":" for 
+                                                  IPv6. */
+    pj_cis_t pjsip_VIA_PARAM_SPEC_ESC;	     /**< .. as above without '%' */
+    pj_cis_t pjsip_HEX_SPEC;  		         /**< Hexadecimal digits.	*/
+    pj_cis_t pjsip_PARAM_CHAR_SPEC;	         /**< For scanning pname (or pvalue
+					                          when it's  not quoted.) in URI */
+    pj_cis_t pjsip_PARAM_CHAR_SPEC_ESC;	     /**< Variant without the escape 
+                                                  ('%') char */
+    pj_cis_t pjsip_HDR_CHAR_SPEC;	         /**< Chars in hname/havalue in URL. */
+    pj_cis_t pjsip_HDR_CHAR_SPEC_ESC;	     /**< Variant without the escape 
+                                                  ('%') char */
+    pj_cis_t pjsip_PROBE_USER_HOST_SPEC;     /**< Hostname characters.	*/
+    pj_cis_t pjsip_PASSWD_SPEC;		         /**< Password.	*/
+    pj_cis_t pjsip_PASSWD_SPEC_ESC;	         /**< Variant without the escape 
+                                                  ('%') char	*/
+    pj_cis_t pjsip_USER_SPEC;		         /**< User */
+    pj_cis_t pjsip_USER_SPEC_ESC;	         /**< Variant without the escape 
+                                                  ('%') char	*/
+    pj_cis_t pjsip_USER_SPEC_LENIENT;	     /**< User, with additional '#' 
+                                                  char */
+    pj_cis_t pjsip_USER_SPEC_LENIENT_ESC;    /**< pjsip_USER_SPEC_ESC with '#' */
+    pj_cis_t pjsip_NOT_NEWLINE;		         /**< For eating up header, basically
+					                              any chars except newlines or 
+                                                  zero. */
+    pj_cis_t pjsip_NOT_COMMA_OR_NEWLINE;     /**< Array elements.		*/
+    pj_cis_t pjsip_NOT_SEMICOLON_OR_NEWLINE; /**< Array elements for privacy header. */
+    pj_cis_t pjsip_DISPLAY_SPEC;	         /**< Used when searching for display name. */
+    pj_cis_t pjsip_OTHER_URI_CONTENT;	     /**< Generic URI content. */
 
 } pjsip_parser_const_t;
 
@@ -419,8 +419,9 @@ PJ_DECL(void) pjsip_parse_generic_array_hdr_imp(pjsip_generic_array_hdr *hdr,
 						pj_scanner *scanner);
 
 /* Parse generic array header with arbitrary delimiter */
-PJ_DECL(void) pjsip_parse_generic_delimited_array_hdr(pjsip_generic_array_hdr *hdr,
-                        pj_scanner *scanner,char delimiter, const pj_cis_t *not_delimiter_or_newline);
+PJ_DECL(void) pjsip_parse_delimited_array_hdr(pjsip_generic_array_hdr *hdr,
+                        pj_scanner *scanner, char delimiter,
+                        const pj_cis_t* const not_delimiter_or_newline);
 
 /* Parse name-addr in header */
 PJ_DECL(pjsip_name_addr*) pjsip_parse_name_addr_imp(pj_scanner *scanner,

--- a/pjsip/include/pjsip/sip_parser.h
+++ b/pjsip/include/pjsip/sip_parser.h
@@ -327,57 +327,59 @@ PJ_DECL(pj_status_t) pjsip_parse_headers( pj_pool_t *pool, char *input,
  */
 typedef struct pjsip_parser_const_t
 {
-    const pj_str_t pjsip_USER_STR;	         /**< "user" string constant.    */
-    const pj_str_t pjsip_METHOD_STR;	     /**< "method" string constant   */
-    const pj_str_t pjsip_TRANSPORT_STR;	     /**< "transport" string const.  */
-    const pj_str_t pjsip_MADDR_STR;	         /**< "maddr" string const.	*/
-    const pj_str_t pjsip_LR_STR;	         /**< "lr" string const.		*/
-    const pj_str_t pjsip_SIP_STR;	         /**< "sip" string constant.	*/
-    const pj_str_t pjsip_SIPS_STR;	         /**< "sips" string constant.    */
-    const pj_str_t pjsip_TEL_STR;	         /**< "tel" string constant.	*/
-    const pj_str_t pjsip_BRANCH_STR;	     /**< "branch" string constant.  */
-    const pj_str_t pjsip_TTL_STR;	         /**< "ttl" string constant.	*/
-    const pj_str_t pjsip_RECEIVED_STR;	     /**< "received" string const.   */
-    const pj_str_t pjsip_Q_STR;		         /**< "q" string constant.	*/
-    const pj_str_t pjsip_EXPIRES_STR;	     /**< "expires" string constant. */
-    const pj_str_t pjsip_TAG_STR;	         /**< "tag" string constant.	*/
-    const pj_str_t pjsip_RPORT_STR;	         /**< "rport" string const.	*/
-    const pj_str_t pjsip_INDEX_STR;	         /**< "index" string constant.	*/
+    const pj_str_t pjsip_USER_STR;           /**< "user" string constant. */
+    const pj_str_t pjsip_METHOD_STR;         /**< "method" string constant */
+    const pj_str_t pjsip_TRANSPORT_STR;      /**< "transport" string const. */
+    const pj_str_t pjsip_MADDR_STR;          /**< "maddr" string const.  */
+    const pj_str_t pjsip_LR_STR;             /**< "lr" string const.    */
+    const pj_str_t pjsip_SIP_STR;            /**< "sip" string constant.  */
+    const pj_str_t pjsip_SIPS_STR;           /**< "sips" string constant.    */
+    const pj_str_t pjsip_TEL_STR;            /**< "tel" string constant.  */
+    const pj_str_t pjsip_BRANCH_STR;         /**< "branch" string constant.  */
+    const pj_str_t pjsip_TTL_STR;            /**< "ttl" string constant.  */
+    const pj_str_t pjsip_RECEIVED_STR;       /**< "received" string const.   */
+    const pj_str_t pjsip_Q_STR;              /**< "q" string constant.  */
+    const pj_str_t pjsip_EXPIRES_STR;        /**< "expires" string constant. */
+    const pj_str_t pjsip_TAG_STR;            /**< "tag" string constant.  */
+    const pj_str_t pjsip_RPORT_STR;          /**< "rport" string const.  */
+    const pj_str_t pjsip_INDEX_STR;          /**< "index" string constant.  */
 
-    pj_cis_t pjsip_HOST_SPEC;		         /**< For scanning host part.	*/
-    pj_cis_t pjsip_DIGIT_SPEC;		         /**< Decimal digits		*/
-    pj_cis_t pjsip_ALPHA_SPEC;		         /**< Alpha (A-Z, a-z)		*/
-    pj_cis_t pjsip_ALNUM_SPEC;		         /**< Decimal + Alpha.		*/
-    pj_cis_t pjsip_TOKEN_SPEC;		         /**< Token.			*/
-    pj_cis_t pjsip_TOKEN_SPEC_ESC;	         /**< Token without '%' character */
-    pj_cis_t pjsip_VIA_PARAM_SPEC;	         /**< Via param is token + ":" for 
+    pj_cis_t pjsip_HOST_SPEC;                /**< For scanning host part.  */
+    pj_cis_t pjsip_DIGIT_SPEC;               /**< Decimal digits    */
+    pj_cis_t pjsip_ALPHA_SPEC;               /**< Alpha (A-Z, a-z)    */
+    pj_cis_t pjsip_ALNUM_SPEC;               /**< Decimal + Alpha.    */
+    pj_cis_t pjsip_TOKEN_SPEC;               /**< Token.      */
+    pj_cis_t pjsip_TOKEN_SPEC_ESC;           /**< Token without '%' character */
+    pj_cis_t pjsip_VIA_PARAM_SPEC;           /**< Via param is token + ":" for
                                                   IPv6. */
-    pj_cis_t pjsip_VIA_PARAM_SPEC_ESC;	     /**< .. as above without '%' */
-    pj_cis_t pjsip_HEX_SPEC;  		         /**< Hexadecimal digits.	*/
-    pj_cis_t pjsip_PARAM_CHAR_SPEC;	         /**< For scanning pname (or pvalue
-					                          when it's  not quoted.) in URI */
-    pj_cis_t pjsip_PARAM_CHAR_SPEC_ESC;	     /**< Variant without the escape 
+    pj_cis_t pjsip_VIA_PARAM_SPEC_ESC;       /**< .. as above without '%' */
+    pj_cis_t pjsip_HEX_SPEC;                 /**< Hexadecimal digits.  */
+    pj_cis_t pjsip_PARAM_CHAR_SPEC;          /**< For scanning pname (or pvalue
+                                                  when it's  not quoted.) in URI */
+    pj_cis_t pjsip_PARAM_CHAR_SPEC_ESC;      /**< Variant without the escape
                                                   ('%') char */
-    pj_cis_t pjsip_HDR_CHAR_SPEC;	         /**< Chars in hname/havalue in URL. */
-    pj_cis_t pjsip_HDR_CHAR_SPEC_ESC;	     /**< Variant without the escape 
+    pj_cis_t pjsip_HDR_CHAR_SPEC;            /**< Chars in hname/havalue in URL. */
+    pj_cis_t pjsip_HDR_CHAR_SPEC_ESC;        /**< Variant without the escape
                                                   ('%') char */
-    pj_cis_t pjsip_PROBE_USER_HOST_SPEC;     /**< Hostname characters.	*/
-    pj_cis_t pjsip_PASSWD_SPEC;		         /**< Password.	*/
-    pj_cis_t pjsip_PASSWD_SPEC_ESC;	         /**< Variant without the escape 
-                                                  ('%') char	*/
-    pj_cis_t pjsip_USER_SPEC;		         /**< User */
-    pj_cis_t pjsip_USER_SPEC_ESC;	         /**< Variant without the escape 
-                                                  ('%') char	*/
-    pj_cis_t pjsip_USER_SPEC_LENIENT;	     /**< User, with additional '#' 
+    pj_cis_t pjsip_PROBE_USER_HOST_SPEC;     /**< Hostname characters.  */
+    pj_cis_t pjsip_PASSWD_SPEC;              /**< Password.  */
+    pj_cis_t pjsip_PASSWD_SPEC_ESC;          /**< Variant without the escape
+                                                  ('%') char  */
+    pj_cis_t pjsip_USER_SPEC;                /**< User */
+    pj_cis_t pjsip_USER_SPEC_ESC;            /**< Variant without the escape
+                                                  ('%') char  */
+    pj_cis_t pjsip_USER_SPEC_LENIENT;        /**< User, with additional '#'
                                                   char */
     pj_cis_t pjsip_USER_SPEC_LENIENT_ESC;    /**< pjsip_USER_SPEC_ESC with '#' */
-    pj_cis_t pjsip_NOT_NEWLINE;		         /**< For eating up header, basically
-					                              any chars except newlines or 
+    pj_cis_t pjsip_NOT_NEWLINE;              /**< For eating up header, basically
+                                                  any chars except newlines or
                                                   zero. */
-    pj_cis_t pjsip_NOT_COMMA_OR_NEWLINE;     /**< Array elements.		*/
-    pj_cis_t pjsip_NOT_SEMICOLON_OR_NEWLINE; /**< Array elements for privacy header. */
-    pj_cis_t pjsip_DISPLAY_SPEC;	         /**< Used when searching for display name. */
-    pj_cis_t pjsip_OTHER_URI_CONTENT;	     /**< Generic URI content. */
+    pj_cis_t pjsip_NOT_COMMA_OR_NEWLINE;     /**< Array elements.    */
+    pj_cis_t pjsip_NOT_SEMICOLON_OR_NEWLINE; /**< Array elements for privacy
+                                                  header. */
+    pj_cis_t pjsip_DISPLAY_SPEC;             /**< Used when searching for display
+                                                  name. */
+    pj_cis_t pjsip_OTHER_URI_CONTENT;        /**< Generic URI content. */
 
 } pjsip_parser_const_t;
 

--- a/pjsip/include/pjsip/sip_parser.h
+++ b/pjsip/include/pjsip/sip_parser.h
@@ -374,6 +374,7 @@ typedef struct pjsip_parser_const_t
 					     any chars except newlines or
 					     zero.			*/
     pj_cis_t pjsip_NOT_COMMA_OR_NEWLINE;/**< Array elements.		*/
+    pj_cis_t pjsip_NOT_SEMICOLON_OR_NEWLINE;/**< Array elements for privacy header.       */
     pj_cis_t pjsip_DISPLAY_SPEC;	/**< Used when searching for display
 					     name.			*/
     pj_cis_t pjsip_OTHER_URI_CONTENT;	/**< Generic URI content.	*/
@@ -416,6 +417,10 @@ PJ_DECL(void) pjsip_parse_end_hdr_imp ( pj_scanner *scanner );
 /* Parse generic array header */
 PJ_DECL(void) pjsip_parse_generic_array_hdr_imp(pjsip_generic_array_hdr *hdr,
 						pj_scanner *scanner);
+
+/* Parse generic array header with arbitrary delimiter */
+PJ_DECL(void) pjsip_parse_generic_delimited_array_hdr(pjsip_generic_array_hdr *hdr,
+                        pj_scanner *scanner,char delimiter, const pj_cis_t *not_delimiter_or_newline);
 
 /* Parse name-addr in header */
 PJ_DECL(pjsip_name_addr*) pjsip_parse_name_addr_imp(pj_scanner *scanner,

--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -885,37 +885,33 @@ static pjsip_generic_int_hdr* pjsip_generic_int_hdr_shallow_clone( pj_pool_t *po
     return hdr;
 }
 
-
 ///////////////////////////////////////////////////////////////////////////////
 /*
  * Print function for a generic array header with an arbitrary delimiter.
  * The generic array header will use this print function with ', ' as a delimiter,
  * the privacy header will use it with '; '.
  */
-int pjsip_generic_array_hdr_delimited_print( pjsip_generic_array_hdr *hdr,
-                      char *buf, pj_size_t size, char *delimiter, size_t delimiter_length)
+int pjsip_delimited_array_hdr_print( pjsip_generic_array_hdr *hdr,
+                      char *buf, pj_size_t size, const pj_str_t *delimiter)
 {
-    char *p = buf, *endbuf = buf+size;
-    const pj_str_t *hname = pjsip_use_compact_form? &hdr->sname : &hdr->name;
+    char *p = buf;
+    char *endbuf = buf + size;
+    const pj_str_t *hname = pjsip_use_compact_form ? &hdr->sname : &hdr->name;
 
     copy_advance(p, (*hname));
     *p++ = ':';
     *p++ = ' ';
 
     if (hdr->count > 0) {
-    unsigned i;
-    int printed;
-    copy_advance(p, hdr->values[0]);
-    for (i=1; i<hdr->count; ++i) {
-        copy_advance_pair(p, delimiter, delimiter_length, hdr->values[i]);
+        unsigned i;
+        int printed;
+        copy_advance(p, hdr->values[0]);
+        for (i=1; i<hdr->count; ++i) {
+            copy_advance_pair(p, delimiter->ptr, delimiter->slen, hdr->values[i]);
+        }
     }
-    }
-
     return p - buf;
 }
-
-
-
 
 ///////////////////////////////////////////////////////////////////////////////
 /*
@@ -958,10 +954,12 @@ PJ_DEF(pjsip_generic_array_hdr*) pjsip_generic_array_hdr_create( pj_pool_t *pool
 
 }
 
+
 static int pjsip_generic_array_hdr_print( pjsip_generic_array_hdr *hdr,
 					  char *buf, pj_size_t size)
 {
-    return pjsip_generic_array_hdr_delimited_print(hdr, buf, size, ", ", 2);
+    pj_str_t comma_delimiter = {", ", 2};
+    return pjsip_delimited_array_hdr_print(hdr, buf, size, &comma_delimiter);
 }
 
 static pjsip_generic_array_hdr* pjsip_generic_array_hdr_clone( pj_pool_t *pool,

--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -885,6 +885,38 @@ static pjsip_generic_int_hdr* pjsip_generic_int_hdr_shallow_clone( pj_pool_t *po
     return hdr;
 }
 
+
+///////////////////////////////////////////////////////////////////////////////
+/*
+ * Print function for a generic array header with an arbitrary delimiter.
+ * The generic array header will use this print function with ', ' as a delimiter,
+ * the privacy header will use it with '; '.
+ */
+int pjsip_generic_array_hdr_delimited_print( pjsip_generic_array_hdr *hdr,
+                      char *buf, pj_size_t size, char *delimiter, size_t delimiter_length)
+{
+    char *p = buf, *endbuf = buf+size;
+    const pj_str_t *hname = pjsip_use_compact_form? &hdr->sname : &hdr->name;
+
+    copy_advance(p, (*hname));
+    *p++ = ':';
+    *p++ = ' ';
+
+    if (hdr->count > 0) {
+    unsigned i;
+    int printed;
+    copy_advance(p, hdr->values[0]);
+    for (i=1; i<hdr->count; ++i) {
+        copy_advance_pair(p, delimiter, delimiter_length, hdr->values[i]);
+    }
+    }
+
+    return p - buf;
+}
+
+
+
+
 ///////////////////////////////////////////////////////////////////////////////
 /*
  * Generic array header.
@@ -929,23 +961,7 @@ PJ_DEF(pjsip_generic_array_hdr*) pjsip_generic_array_hdr_create( pj_pool_t *pool
 static int pjsip_generic_array_hdr_print( pjsip_generic_array_hdr *hdr,
 					  char *buf, pj_size_t size)
 {
-    char *p = buf, *endbuf = buf+size;
-    const pj_str_t *hname = pjsip_use_compact_form? &hdr->sname : &hdr->name;
-
-    copy_advance(p, (*hname));
-    *p++ = ':';
-    *p++ = ' ';
-
-    if (hdr->count > 0) {
-	unsigned i;
-	int printed;
-	copy_advance(p, hdr->values[0]);
-	for (i=1; i<hdr->count; ++i) {
-	    copy_advance_pair(p, ", ", 2, hdr->values[i]);
-	}
-    }
-
-    return p - buf;
+    return pjsip_generic_array_hdr_delimited_print(hdr, buf, size, ", ", 2);
 }
 
 static pjsip_generic_array_hdr* pjsip_generic_array_hdr_clone( pj_pool_t *pool,

--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -116,7 +116,7 @@ static pjsip_parser_const_t pconst =
     { "expires", 7 },	/* pjsip_EXPIRES_STR	*/
     { "tag", 3 },	/* pjsip_TAG_STR	*/
     { "rport", 5},	/* pjsip_RPORT_STR	*/
-    { "index", 5}	/* pjsip_INDEX_STR	*/
+    { "index", 5},	/* pjsip_INDEX_STR	*/
 };
 
 /* Character Input Specification buffer. */
@@ -1751,9 +1751,9 @@ PJ_DEF(void) pjsip_parse_end_hdr_imp( pj_scanner *scanner )
 }
 
 /* Parse generic array with an arbitrary delimiter. */
-void pjsip_parse_generic_delimited_array_hdr(
+void pjsip_parse_delimited_array_hdr(
 				pjsip_generic_array_hdr *hdr, pj_scanner *scanner,
-				char delimiter, const pj_cis_t *not_delimiter_or_newline)
+				char delimiter, const pj_cis_t* const not_delimiter_or_newline)
 {
     /* Some header fields allow empty elements in the value:
      *   Accept, Allow, Supported
@@ -1792,7 +1792,7 @@ end:
 static void parse_generic_array_hdr( pjsip_generic_array_hdr *hdr,
 				     pj_scanner *scanner)
 {
-    pjsip_parse_generic_delimited_array_hdr(hdr, scanner, ',', &pconst.pjsip_NOT_COMMA_OR_NEWLINE);
+    pjsip_parse_delimited_array_hdr(hdr, scanner, ',', &pconst.pjsip_NOT_COMMA_OR_NEWLINE);
 }
 
 /* Parse generic array header. */


### PR DESCRIPTION
Refactored parse_generic_array_hdr to allow for an arbitrary delimiter. This is to allow the delimiter in a privacy header to be a semicolon rather than a comma, as per issue #1514.