### PR TITLE
[Reviewer: RKD] Expose pjsip_generic_array_header_clone methods

### DIFF
--- a/pjsip/include/pjsip/sip_msg.h
+++ b/pjsip/include/pjsip/sip_msg.h
@@ -1143,6 +1143,28 @@ PJ_DECL(pjsip_generic_array_hdr*) pjsip_generic_array_hdr_create(pj_pool_t *pool
 							     const pj_str_t *hname);
 
 /**
+ * Clone a generic array header
+ *
+ * @param pool	    Pool to allocate memory from.
+ * @param hdr	      Header to clone.
+ *
+ * @return Cloned array header
+ */
+pjsip_generic_array_hdr* pjsip_generic_array_hdr_clone( pj_pool_t *pool,
+						 const pjsip_generic_array_hdr *hdr);
+
+/**
+ * Shallow clone a generic array header
+ *
+ * @param pool	    Pool to allocate memory from.
+ * @param hdr	      Header to clone.
+ *
+ * @return Cloned array header
+ */
+pjsip_generic_array_hdr* pjsip_generic_array_hdr_shallow_clone( pj_pool_t *pool,
+						 const pjsip_generic_array_hdr *hdr);
+
+/**
  * Initialize a preallocated memory with the header structure. This function
  * should only be called when application uses its own memory allocation to
  * allocate memory block for the specified header (e.g. in C++, when the

--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -918,10 +918,6 @@ int pjsip_delimited_array_hdr_print( pjsip_generic_array_hdr *hdr,
  * Generic array header.
  */
 static int pjsip_generic_array_hdr_print( pjsip_generic_array_hdr *hdr, char *buf, pj_size_t size);
-static pjsip_generic_array_hdr* pjsip_generic_array_hdr_clone( pj_pool_t *pool,
-						 const pjsip_generic_array_hdr *hdr);
-static pjsip_generic_array_hdr* pjsip_generic_array_hdr_shallow_clone( pj_pool_t *pool,
-						 const pjsip_generic_array_hdr *hdr);
 
 static pjsip_hdr_vptr generic_array_hdr_vptr =
 {
@@ -962,7 +958,7 @@ static int pjsip_generic_array_hdr_print( pjsip_generic_array_hdr *hdr,
     return pjsip_delimited_array_hdr_print(hdr, buf, size, &comma_delimiter);
 }
 
-static pjsip_generic_array_hdr* pjsip_generic_array_hdr_clone( pj_pool_t *pool,
+pjsip_generic_array_hdr* pjsip_generic_array_hdr_clone( pj_pool_t *pool,
 						 const pjsip_generic_array_hdr *rhs)
 {
     unsigned i;
@@ -981,7 +977,7 @@ static pjsip_generic_array_hdr* pjsip_generic_array_hdr_clone( pj_pool_t *pool,
 }
 
 
-static pjsip_generic_array_hdr* pjsip_generic_array_hdr_shallow_clone( pj_pool_t *pool,
+pjsip_generic_array_hdr* pjsip_generic_array_hdr_shallow_clone( pj_pool_t *pool,
 						 const pjsip_generic_array_hdr *rhs)
 {
     pjsip_generic_array_hdr *hdr = PJ_POOL_ALLOC_T(pool, pjsip_generic_array_hdr);


### PR DESCRIPTION
Rob,

This exposes some methods from PJSIP which we need to correctly implement Privacy header printing.