### PR TITLE
[Reviewer: Ellie] Allow dupe of string from const buffer and length

### DIFF
--- a/pjlib/include/pj/string.h
+++ b/pjlib/include/pj/string.h
@@ -262,6 +262,21 @@ PJ_IDECL(pj_str_t*) pj_strdup2_with_null(pj_pool_t *pool,
 PJ_IDECL(pj_str_t) pj_strdup3(pj_pool_t *pool, const char *src);
 
 /**
+ * Duplicate string.
+ *
+ * @param pool	    The pool.
+ * @param dst	    The string result.
+ * @param src	    The string to duplicate.
+ * @param len	    The length of the string to duplicate.
+ *
+ * @return the string result.
+ */
+PJ_IDECL(pj_str_t*) pj_strdup4(pj_pool_t *pool,
+			       pj_str_t *dst,
+			       const char *src,
+			       pj_size_t len);
+
+/**
  * Return the length of the string.
  *
  * @param str	    The string.

--- a/pjlib/include/pj/string_i.h
+++ b/pjlib/include/pj/string_i.h
@@ -91,6 +91,21 @@ PJ_IDEF(pj_str_t) pj_strdup3(pj_pool_t *pool, const char *src)
     return temp;
 }
 
+PJ_IDEF(pj_str_t*) pj_strdup4(pj_pool_t *pool,
+			      pj_str_t *dst,
+			      const char *src,
+			      pj_size_t len)
+{
+    dst->slen = len;
+    if (dst->slen) {
+	dst->ptr = (char*)pj_pool_alloc(pool, dst->slen);
+	pj_memcpy(dst->ptr, src, dst->slen);
+    } else {
+	dst->ptr = NULL;
+    }
+    return dst;
+}
+
 PJ_IDEF(pj_str_t*) pj_strassign( pj_str_t *dst, pj_str_t *src )
 {
     dst->ptr = src->ptr;


### PR DESCRIPTION
Currently there's no way in pjsip to construct a pj_str_t from a constant buffer and length. The other pj_strdup() functions either assume you have a pj_str_t, or have a C style null terminated buffer. This adds another version which takes both a buffer and a length.