### PR TITLE
Add option to bypass media init in PJSUA for applications which only care about signaling.

### DIFF
--- a/pjsip/include/pjsua-lib/pjsua.h
+++ b/pjsip/include/pjsua-lib/pjsua.h
@@ -5657,6 +5657,14 @@ struct pjsua_media_config
      * Default: PJ_FALSE
      */
     pj_bool_t no_smart_media_update;
+
+    /**
+     * Whether to bypass initialization of the PJSUA media subsystem, for
+     * example in applications that are interested only in signaling.
+     *
+     * Default: PJ_FALSE
+     */
+    pj_bool_t no_init_media;
 };
 
 

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -1000,7 +1000,7 @@ PJ_DEF(pj_status_t) pjsua_init( const pjsua_config *ua_cfg,
         /* Initialize PJSUA media subsystem */
         status = pjsua_media_subsys_init(media_cfg);
         if (status != PJ_SUCCESS)
-    	goto on_error;
+            goto on_error;
     }
 
 

--- a/pjsip/src/pjsua-lib/pjsua_core.c
+++ b/pjsip/src/pjsua-lib/pjsua_core.c
@@ -330,6 +330,7 @@ PJ_DEF(void) pjsua_media_config_default(pjsua_media_config *cfg)
 
     cfg->turn_conn_type = PJ_TURN_TP_UDP;
     cfg->vid_preview_enable_native = PJ_TRUE;
+    cfg->no_init_media = PJ_FALSE;
 }
 
 /*****************************************************************************
@@ -995,10 +996,12 @@ PJ_DEF(pj_status_t) pjsua_init( const pjsua_config *ua_cfg,
 	goto on_error;
     }
 
-    /* Initialize PJSUA media subsystem */
-    status = pjsua_media_subsys_init(media_cfg);
-    if (status != PJ_SUCCESS)
-	goto on_error;
+    if (!media_cfg->no_init_media) {
+        /* Initialize PJSUA media subsystem */
+        status = pjsua_media_subsys_init(media_cfg);
+        if (status != PJ_SUCCESS)
+    	goto on_error;
+    }
 
 
     /* Init core SIMPLE module : */


### PR DESCRIPTION
Otherwise pjsua sits there for 5 minutes trying to initialize audio devices on systems that don't have any.