### PR TITLE
[Reviewer: EM] Mark failed transports to avoid reuse

### DIFF
--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -782,13 +782,13 @@ struct pjsip_transport
 {
     char		    obj_name[PJ_MAX_OBJ_NAME];	/**< Name. */
 
-    pj_pool_t		   *pool;			/**< Pool used by transport.		*/
-    pj_atomic_t		   *ref_cnt;		/**< Reference counter.				*/
-    pj_lock_t		   *lock;			/**< Lock object.					*/
-    pj_bool_t		    tracing;		/**< Tracing enabled?				*/
-    pj_bool_t		    is_shutdown;	/**< Being shutdown?				*/
-    pj_bool_t		    is_destroying;	/**< Destroy in progress?			*/
-    pj_bool_t		    is_failed;		/**< Failed with tranport error?	*/
+    pj_pool_t  	*pool;        	/**< Pool used by transport.    	*/
+    pj_atomic_t	*ref_cnt;     	/**< Reference counter.         	*/
+    pj_lock_t  	*lock;        	/**< Lock object.               	*/
+    pj_bool_t  	tracing;      	/**< Tracing enabled?           	*/
+    pj_bool_t  	is_shutdown;  	/**< Being shutdown?            	*/
+    pj_bool_t  	is_destroying;	/**< Destroy in progress?       	*/
+    pj_bool_t  	is_failed;    	/**< Failed with tranport error?	*/
 
     /** Key for indexing this transport in hash table. */
     pjsip_transport_key	    key;

--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -1,5 +1,5 @@
 /* $Id: sip_transport.h 4275 2012-10-04 06:11:58Z bennylp $ */
-/* 
+/*
  * Copyright (C) 2008-2011 Teluu Inc. (http://www.teluu.com)
  * Copyright (C) 2003-2008 Benny Prijono <benny@prijono.org>
  * Copyright (C) 2013  Metaswitch Networks Ltd
@@ -788,6 +788,7 @@ struct pjsip_transport
     pj_bool_t		    tracing;	    /**< Tracing enabled?	    */
     pj_bool_t		    is_shutdown;    /**< Being shutdown?	    */
     pj_bool_t		    is_destroying;  /**< Destroy in progress?	    */
+    pj_bool_t		    is_failed;  /**< Failed with tranport error?	    */
 
     /** Key for indexing this transport in hash table. */
     pjsip_transport_key	    key;
@@ -1396,10 +1397,10 @@ typedef enum pjsip_transport_state
     PJSIP_TP_STATE_DISCONNECTED,    /**< Transport disconnected, applicable
 					 only to connection-oriented
 					 transports such as TCP and TLS.    */
-    PJSIP_TP_STATE_DESTROYED	    /**< Transport destroyed. When the 
-					 transport is in this state, its 
-					 public fields may be read, but it 
-					 is illegal to perform any 
+    PJSIP_TP_STATE_DESTROYED	    /**< Transport destroyed. When the
+					 transport is in this state, its
+					 public fields may be read, but it
+					 is illegal to perform any
 					 operations on the transport.       */
 } pjsip_transport_state;
 

--- a/pjsip/include/pjsip/sip_transport.h
+++ b/pjsip/include/pjsip/sip_transport.h
@@ -782,13 +782,13 @@ struct pjsip_transport
 {
     char		    obj_name[PJ_MAX_OBJ_NAME];	/**< Name. */
 
-    pj_pool_t		   *pool;	    /**< Pool used by transport.    */
-    pj_atomic_t		   *ref_cnt;	    /**< Reference counter.	    */
-    pj_lock_t		   *lock;	    /**< Lock object.		    */
-    pj_bool_t		    tracing;	    /**< Tracing enabled?	    */
-    pj_bool_t		    is_shutdown;    /**< Being shutdown?	    */
-    pj_bool_t		    is_destroying;  /**< Destroy in progress?	    */
-    pj_bool_t		    is_failed;  /**< Failed with tranport error?	    */
+    pj_pool_t		   *pool;			/**< Pool used by transport.		*/
+    pj_atomic_t		   *ref_cnt;		/**< Reference counter.				*/
+    pj_lock_t		   *lock;			/**< Lock object.					*/
+    pj_bool_t		    tracing;		/**< Tracing enabled?				*/
+    pj_bool_t		    is_shutdown;	/**< Being shutdown?				*/
+    pj_bool_t		    is_destroying;	/**< Destroy in progress?			*/
+    pj_bool_t		    is_failed;		/**< Failed with tranport error?	*/
 
     /** Key for indexing this transport in hash table. */
     pjsip_transport_key	    key;

--- a/pjsip/src/pjsip/sip_transport.c
+++ b/pjsip/src/pjsip/sip_transport.c
@@ -1,5 +1,5 @@
 /* $Id: sip_transport.c 4295 2012-11-06 05:22:11Z nanang $ */
-/* 
+/*
  * Copyright (C) 2008-2011 Teluu Inc. (http://www.teluu.com)
  * Copyright (C) 2003-2008 Benny Prijono <benny@prijono.org>
  * Copyright (C) 2013  Metaswitch Networks Ltd
@@ -1005,7 +1005,7 @@ PJ_DEF(pj_status_t) pjsip_transport_dec_ref( pjsip_transport *tp )
 	 */
 	if (pj_atomic_get(tp->ref_cnt) == 0 && !tp->is_destroying) {
 	    pj_time_val delay;
-	
+
 	    /* If transport is in graceful shutdown, then this is the
 	     * last user who uses the transport. Schedule to destroy the
 	     * transport immediately. Otherwise schedule idle timer.
@@ -1117,7 +1117,7 @@ static pj_status_t destroy_transport( pjsip_tpmgr *mgr,
 	pj_bzero(&state_info, sizeof(state_info));
 	(*state_cb)(tp, PJSIP_TP_STATE_DESTROYED, &state_info);
     }
-    
+
     /* Destroy. */
     return tp->destroy(tp);
 }
@@ -1534,7 +1534,7 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_destroy( pjsip_tpmgr *mgr )
     while (itr != NULL) {
 	pj_hash_iterator_t *next;
 	pjsip_transport *transport;
-	
+
 	transport = (pjsip_transport*) pj_hash_this(mgr->table, itr);
 
 	next = pj_hash_next(mgr->table, itr);
@@ -1550,7 +1550,7 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_destroy( pjsip_tpmgr *mgr )
     factory = mgr->factory_list.next;
     while (factory != &mgr->factory_list) {
 	pjsip_tpfactory *next = factory->next;
-	
+
 	factory->destroy(factory);
 
 	factory = next;
@@ -1654,13 +1654,13 @@ PJ_DEF(pj_ssize_t) pjsip_tpmgr_receive_packet( pjsip_tpmgr *mgr,
 		    /* Exhaust all data. */
 		    return rdata->pkt_info.len;
      		} else if (msg_status == PJSIP_EMISSINGHDR) {
-                    /* pjsip_find_msg will only return this if it has received 
+                    /* pjsip_find_msg will only return this if it has received
                      * the blank line denoting end of headers but cannot find a
                      * Content-Length header.
                      *
                      * This is not allowed for TCP according to RFC3261 (20.14)
                      */
-                    PJ_LOG(3,(THIS_FILE, 
+                    PJ_LOG(3,(THIS_FILE,
                               "No content-length header in TCP packet"));
                     return -PJSIP_EMISSINGHDR;
 		} else {
@@ -1945,7 +1945,7 @@ PJ_DEF(pj_status_t) pjsip_tpmgr_acquire_transport2(pjsip_tpmgr *mgr,
 	    }
 	}
 
-	if (transport!=NULL && !transport->is_shutdown) {
+	if (transport!=NULL && !transport->is_shutdown && !transport->is_failed) {
 	    /*
 	     * Transport found!
 	     */

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -410,7 +410,7 @@ PJ_DEF(pj_status_t) pjsip_tcp_transport_start3(
 	asock_cfg.async_cnt = MAX_ASYNC_CNT;
     else
 	asock_cfg.async_cnt = cfg->async_cnt;
-	
+
     asock_cfg.concurrency = 1;
 
     pj_bzero(&listener_cb, sizeof(listener_cb));
@@ -1536,6 +1536,12 @@ static pj_bool_t on_connect_complete(pj_activesock_t *asock,
     if (status != PJ_SUCCESS) {
 
 	tcp_perror(tcp->base.obj_name, "TCP connect() error", status);
+
+  /* Mark the transport as failed, ahead of it being shutdown below.  This
+   * avoids it from being selected to send any further messages as a result
+   * of processing in the on_data_sent(), which happens before the transaction
+   * gets marked as shutdown. */
+  tcp->base.is_failed = PJ_TRUE;
 
 	/* Cancel all delayed transmits */
 	while (!pj_list_empty(&tcp->delayed_list)) {

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1537,11 +1537,11 @@ static pj_bool_t on_connect_complete(pj_activesock_t *asock,
 
 	tcp_perror(tcp->base.obj_name, "TCP connect() error", status);
 
-  /* Mark the transport as failed, ahead of it being shutdown below.  This
-   * avoids it from being selected to send any further messages as a result
-   * of processing in the on_data_sent(), which happens before the transaction
-   * gets marked as shutdown. */
-  tcp->base.is_failed = PJ_TRUE;
+	/* Mark the transport as failed, ahead of it being shutdown below.  This
+	 * avoids it from being selected to send any further messages as a result
+	 * of processing in the on_data_sent(), which happens before the
+	 * transaction gets marked as shutdown. */
+	tcp->base.is_failed = PJ_TRUE;
 
 	/* Cancel all delayed transmits */
 	while (!pj_list_empty(&tcp->delayed_list)) {


### PR DESCRIPTION
There is a problem with how pjsip deals with transport errors that affects that type of routing that is only generally performed in a BGCF.  When pjsip hits a transport error while sending a SIP INVITE over TCP, it notifies sprout, which internally generates a SIP 503 response.  This response is notified up to the sproutlet, which may choose to try sending that INVITE via an alternative route.  If the second route has the same next first hop (e.g. both the primary and secondary routes go via the local IBCF), then pjsip will attempt to reuse the failed transport (see below for why).  Retrying on a failed transport does not produce the same notfications up to the application, so the second attempt will hang until the inbound SIP transaction times out.

pjsip has a mechanism for shutting down transports after they hit an error.  A transport that has been shut down cannot be selected to be reused for sending any future messages.  The problem comes from *when* the shutdown occurs.  In the case of a transport error due to timeout, a thread handling the timeout calls into the `on_connect_complete()` method, which will:
 - Identify that the connection attempt has failed
 - Notify the application, which will produce the internal 503, giving the sproutlet chance to try an alternate destination
 - Shut down the failed transport

The transport isn't shut down before the application is notified, so any attempt to send another request to the same address/port will select the existing transport.  pjsip can't shut down the transport before notifying the application, because the application may inspect/manipulate the transport in this notification, and it must remain valid.

The fix in this pull request adds a new flag to the transport, to indicate that it has hit a transport error, and shouldn't be selected for sending any additional requests.