### PR TITLE
Close transaction destruction race condition

### DIFF
--- a/pjlib/src/pj/lock.c
+++ b/pjlib/src/pj/lock.c
@@ -359,11 +359,10 @@ static pj_status_t grp_lock_destroy(LOCK_OBJ *p)
     }
 
     /* Call callbacks */
-    cb = glock->destroy_list.next;
-    while (cb != &glock->destroy_list) {
-	grp_destroy_callback *next = cb->next;
+    while (glock->destroy_list.next != &glock->destroy_list) {
+	cb = glock->destroy_list.next;
+	glock->destroy_list.next = cb->next;
 	cb->handler(cb->comp);
-	cb = next;
     }
 
     pj_lock_destroy(glock->own_lock);

--- a/pjsip/include/pjsip/sip_transaction.h
+++ b/pjsip/include/pjsip/sip_transaction.h
@@ -312,6 +312,26 @@ PJ_DECL(void) pjsip_tsx_recv_msg( pjsip_transaction *tsx,
 				  pjsip_rx_data *rdata);
 
 /**
+ * Call this function to manually feed a message to the transaction.
+ * For UAS transaction, application MUST call this function after
+ * UAS transaction has been created.
+ *
+ * This function SHOULD only be called to pass initial request message
+ * to UAS transaction. Before this function returns, on_tsx_state()
+ * callback of the transaction user will be called. If response message
+ * is passed to this function, then on_rx_response() will also be called
+ * before on_tsx_state().
+ *
+ * @param tsx	    The transaction.
+ * @param rdata	    The message.
+ * @param lock_ref  Whether the group lock has been referenced and should
+ *                  be decremented after it has been taken.
+ */
+PJ_DECL(void) pjsip_tsx_recv_msg2( pjsip_transaction *tsx,
+				   pjsip_rx_data *rdata,
+				   pj_bool_t lock_ref);
+
+/**
  * Transmit message in tdata with this transaction. It is possible to
  * pass NULL in tdata for UAC transaction, which in this case the last 
  * message transmitted, or the request message which was specified when


### PR DESCRIPTION
Matt,

Please can you review my fix to https://github.com/Metaswitch/sprout/issues/1727?  That issue was that a transaction was being destroyed between the transaction hash table (in which it was being looked up) being unlocked and the transaction's own lock being taken.  (It's not possible to take the lock on the transaction while the transaction hash table is locked because this could cause deadlock.)

The bulk of this fix is to increment the reference count on the group lock while the lock on the transaction hash table is held (this is legal, and stops the transaction from being destroyed) and then decrement the reference count once the group lock has actually been taken.  To allow for the case where the transaction has been flagged as destroyed (i.e. all its child resources have been freed) in this window, we also have to check this flag and, if so, pretend that we never found the transaction in the first place.

The fix also includes a tweak to group lock destroy list processing, to ensure that items are removed from the destroy list as they are destroyed, rather than being left in - this is marginally safer, and just feels generally tidier.

I've run the sprout UTs and clearwater-live-test, and will pass to @rkd-msw after you've reviewed for him to run stress against this.

Matt