### PR TITLE
[Reviewer: RKD] Allow list headers to have a trailing comma

### DIFF
--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -1769,9 +1769,11 @@ void pjsip_parse_delimited_array_hdr(
 	return;
     }
 
-    pj_scan_get( scanner, not_delimiter_or_newline,
-		 &hdr->values[hdr->count]);
-    hdr->count++;
+    if (*scanner->curptr != delimiter) {
+      pj_scan_get( scanner, not_delimiter_or_newline,
+	  	           &hdr->values[hdr->count]);
+      hdr->count++;
+    }
 
     while (*scanner->curptr == delimiter) {
 	pj_scan_get_char(scanner);
@@ -1785,9 +1787,11 @@ void pjsip_parse_delimited_array_hdr(
       break;
     }
 
-	pj_scan_get( scanner, not_delimiter_or_newline,
-		     &hdr->values[hdr->count]);
-	hdr->count++;
+    if (*scanner->curptr != delimiter) {
+	  pj_scan_get( scanner, not_delimiter_or_newline,
+	  	           &hdr->values[hdr->count]);
+	    hdr->count++;
+    }
 
 	if (hdr->count >= PJSIP_GENERIC_ARRAY_MAX_COUNT)
 	    break;

--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -1758,9 +1758,8 @@ void pjsip_parse_delimited_array_hdr(
     /* Some header fields allow empty elements in the value:
      *   Accept, Allow, Supported
      */
-    if (pj_scan_is_eof(scanner) ||
-	*scanner->curptr == '\r' || *scanner->curptr == '\n')
-    {
+    if (pj_scan_is_eof(scanner) || IS_NEWLINE(*scanner->curptr))
+	{
 	goto end;
     }
 
@@ -1776,6 +1775,16 @@ void pjsip_parse_delimited_array_hdr(
 
     while (*scanner->curptr == delimiter) {
 	pj_scan_get_char(scanner);
+
+    /* Allow a trailing delimiter with no following value as we have
+     * seen this in the field. This mirrors the allowance of 
+     * completely empty fields above.
+     */
+    if (pj_scan_is_eof(scanner) || IS_NEWLINE(*scanner->curptr))
+    {
+      break;
+    }
+
 	pj_scan_get( scanner, not_delimiter_or_newline,
 		     &hdr->values[hdr->count]);
 	hdr->count++;


### PR DESCRIPTION
Rob,

Could you review this fix to allow us to accept headers (particularly the Supported: header) with a trailing comma?  Passing direct to you since you've looked at this already - hope that's OK.

Neil