### PR TITLE
[Reviewer: RJW2] Check return code of print node.

### DIFF
--- a/pjlib-util/src/pjlib-util/xml.c
+++ b/pjlib-util/src/pjlib-util/xml.c
@@ -295,6 +295,7 @@ PJ_DEF(int) pj_xml_print(const pj_xml_node *node, char *buf, pj_size_t len,
 {
     int prolog_len = 0;
     int printed;
+    int print_node;
 
     if (!node || !buf || !len)
 	return 0;
@@ -307,7 +308,12 @@ PJ_DEF(int) pj_xml_print(const pj_xml_node *node, char *buf, pj_size_t len,
 	prolog_len = prolog.slen;
     }
 
-    printed = xml_print_node(node, 0, buf+prolog_len, len-prolog_len) + prolog_len;
+    print_node = xml_print_node(node, 0, buf+prolog_len, len-prolog_len);
+    if (print_node < 0){
+      return -1;
+    }
+
+    printed = print_node + prolog_len;
     if (printed > 0 && len-printed >= 1) {
 	buf[printed++] = '\n';
     }

--- a/pjlib-util/src/pjlib-util/xml.c
+++ b/pjlib-util/src/pjlib-util/xml.c
@@ -294,8 +294,8 @@ PJ_DEF(int) pj_xml_print(const pj_xml_node *node, char *buf, pj_size_t len,
 			 pj_bool_t include_prolog)
 {
     int prolog_len = 0;
-    int printed;
-    int print_node;
+    int xml_total_len;
+    int xml_print_node_len;
 
     if (!node || !buf || !len)
 	return 0;
@@ -308,16 +308,17 @@ PJ_DEF(int) pj_xml_print(const pj_xml_node *node, char *buf, pj_size_t len,
 	prolog_len = prolog.slen;
     }
 
-    print_node = xml_print_node(node, 0, buf+prolog_len, len-prolog_len);
-    if (print_node < 0){
+    xml_print_node_len = xml_print_node(node, 0, 
+                                        buf + prolog_len, len - prolog_len);
+    if (xml_print_node_len < 0) {
       return -1;
     }
 
-    printed = print_node + prolog_len;
-    if (printed > 0 && len-printed >= 1) {
-	buf[printed++] = '\n';
+    xml_total_len = xml_print_node_len + prolog_len;
+    if (xml_total_len > 0 && len-xml_total_len >= 1) {
+	buf[xml_total_len++] = '\n';
     }
-    return printed;
+    return xml_total_len;
 }
 
 PJ_DEF(pj_xml_node*) pj_xml_node_new(pj_pool_t *pool, const pj_str_t *name)


### PR DESCRIPTION
print_node always gets its return code checked elsewhere, but in this case it was added to a positive number before being checked, so a -1 return code may not be caught.
Add in the check, no test written as it's in pjsip.