### PR TITLE
Make pjsip compatible with different compilers / tools

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -3551,7 +3551,7 @@ if test "$CC_DEF" = ""; then CC_DEF="-D"; fi
 
 if test "$CC_OPTIMIZE" = ""; then CC_OPTIMIZE="-O2"; fi
 
-if test "$CC_CFLAGS" = ""; then CC_CFLAGS="-Wall"; fi
+if test "$CC_CFLAGS" = ""; then CC_CFLAGS="-Wall -c"; fi
 
 
 

--- a/build/cc-auto.mak.in
+++ b/build/cc-auto.mak.in
@@ -1,8 +1,8 @@
-export CC = @CC@ -c
-export CXX = @CXX@ -c
+export CC = @CC@
+export CXX = @CXX@
 export AR = @AR@
 export LD = @LD@
-export LDOUT = -o 
+export LDOUT = -o
 export RANLIB = @RANLIB@
 
 export OBJEXT := .@OBJEXT@

--- a/pjsip-apps/build/Samples.mak
+++ b/pjsip-apps/build/Samples.mak
@@ -55,15 +55,15 @@ $(BINDIR)/%$(HOST_EXE): $(OBJDIR)/%$(OBJEXT) $(PJ_LIB_FILES)
 	    $(_LDFLAGS)
 
 $(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.c
-	$(CC) $(_CFLAGS) \
+	$(CC) -c $(_CFLAGS) \
 	  $(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
-	  $(subst /,$(HOST_PSEP),$<) 
+	  $(subst /,$(HOST_PSEP),$<)
 
 $(OBJDIR):
-	$(subst @@,$(subst /,$(HOST_PSEP),$@),$(HOST_MKDIR)) 
+	$(subst @@,$(subst /,$(HOST_PSEP),$@),$(HOST_MKDIR))
 
 $(BINDIR):
-	$(subst @@,$(subst /,$(HOST_PSEP),$@),$(HOST_MKDIR)) 
+	$(subst @@,$(subst /,$(HOST_PSEP),$@),$(HOST_MKDIR))
 
 depend:
 

--- a/pjsip-apps/build/Samples.mak
+++ b/pjsip-apps/build/Samples.mak
@@ -5,7 +5,7 @@ include ../../build/common.mak
 ###############################################################################
 # Gather all flags.
 #
-export _CFLAGS 	:= $(PJ_CFLAGS) $(CFLAGS)
+export _CFLAGS 	:= $(PJ_CFLAGS) $(_CFLAGS)
 export _CXXFLAGS:= $(PJ_CXXFLAGS)
 export _LDFLAGS := $(PJ_LDFLAGS) $(PJ_LDLIBS) $(LDFLAGS)
 
@@ -55,7 +55,7 @@ $(BINDIR)/%$(HOST_EXE): $(OBJDIR)/%$(OBJEXT) $(PJ_LIB_FILES)
 	    $(_LDFLAGS)
 
 $(OBJDIR)/%$(OBJEXT): $(SRCDIR)/%.c
-	$(CC) -c $(_CFLAGS) \
+	$(CC) $(_CFLAGS) \
 	  $(CC_OUT)$(subst /,$(HOST_PSEP),$@) \
 	  $(subst /,$(HOST_PSEP),$<)
 


### PR DESCRIPTION
Hi Richard (picking you for this PR as you know about PJSIP and best practices when it comes to build infrastructure), 

I've made some tweaks to the PJSIP build infrastructure to make it compatible with different compiler's and tools. The issue before was that PJSIP defined `CC` as `gcc -c`, which means if you try to override `CC` (e.g. when running an analysis tool) everything goes wrong as the tool tries to compile to executables rather than object files. I've changed this so that `CC` just points to the compiler, and the `-c` is passed in the flags parameter. 

Please could you review? I'm not sure this is the right way of doing but if you have a better suggestion then I'm open to it. 