### PR TITLE
[Reviewer: Richard] Improve TCP connect() error log

### DIFF
--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1546,10 +1546,11 @@ static pj_bool_t on_connect_complete(pj_activesock_t *asock,
     if (status != PJ_SUCCESS) {
 
 	tcp_pwarning(tcp->base.obj_name, "TCP connect() error", status);
-	PJ_LOG(2,(tcp->base.obj_name, "Unable to connect to %.*s:%d",
-	    (int)tcp->base.remote_name.host.slen,
-	    tcp->base.remote_name.host.ptr,
-	    tcp->base.remote_name.port));
+	PJ_LOG(2, (tcp->base.obj_name,
+	           "Unable to connect to %.*s:%d",
+	           (int)tcp->base.remote_name.host.slen,
+	           tcp->base.remote_name.host.ptr,
+	           tcp->base.remote_name.port));
 
 	/* Mark the transport as failed, ahead of it being shutdown below.  This
 	 * avoids it from being selected to send any further messages as a result

--- a/pjsip/src/pjsip/sip_transport_tcp.c
+++ b/pjsip/src/pjsip/sip_transport_tcp.c
@@ -1546,6 +1546,10 @@ static pj_bool_t on_connect_complete(pj_activesock_t *asock,
     if (status != PJ_SUCCESS) {
 
 	tcp_pwarning(tcp->base.obj_name, "TCP connect() error", status);
+	PJ_LOG(2,(tcp->base.obj_name, "Unable to connect to %.*s:%d",
+	    (int)tcp->base.remote_name.host.slen,
+	    tcp->base.remote_name.host.ptr,
+	    tcp->base.remote_name.port));
 
 	/* Mark the transport as failed, ahead of it being shutdown below.  This
 	 * avoids it from being selected to send any further messages as a result


### PR DESCRIPTION
Log what host we've failed to connect to.

This is a fix for https://github.com/Metaswitch/clearwater-issues/issues/2223

(I did my best to match existing indentation, which is 1 tab and 4 spaces (!) for the 2nd indent)

### Testing
Tested live: we see logs like

```
19-06-2017 15:37:22.418 UTC Warning pjsip: tcpc0x7fb62004 TCP connect() error: Operation timed out (PJ_ETIMEDOUT) [code=70009]
19-06-2017 15:37:22.418 UTC Warning pjsip: tcpc0x7fb62004 Unable to connect to 5.6.7.8:5060
```

Also double-checked that `make full_test` passes in sprout