### PR TITLE
[Reviewer: Alex] Allow a hash in the username of a SIP URI

### DIFF
--- a/pjsip/src/pjsip/sip_parser.c
+++ b/pjsip/src/pjsip/sip_parser.c
@@ -451,7 +451,7 @@ static pj_status_t init_parser()
 
     status = pj_cis_dup(&pconst.pjsip_PROBE_USER_HOST_SPEC, &pconst.pjsip_ALNUM_SPEC);
     PJ_ASSERT_RETURN(status == PJ_SUCCESS, status);
-    pj_cis_add_str( &pconst.pjsip_PROBE_USER_HOST_SPEC, UNRESERVED ESCAPED USER_UNRESERVED ";" ":");
+    pj_cis_add_str( &pconst.pjsip_PROBE_USER_HOST_SPEC, UNRESERVED ESCAPED USER_UNRESERVED ";" ":" "#");
 
     status = pj_cis_init(&cis_buf, &pconst.pjsip_DISPLAY_SPEC);
     PJ_ASSERT_RETURN(status == PJ_SUCCESS, status);


### PR DESCRIPTION
Alex,

You tightened up the PJSIP parser of username and passwords, so I think you are the right person to review this change.

This change allows # symbols in them.