### PR TITLE
Find blocking events on the transport thread

### DIFF
--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -41,6 +41,10 @@
 #include <pj/compat/socket.h>
 #include <pj/rand.h>
 
+// The length of time (in usecs) that it is acceptable to spend processing an
+// event on the transport thread. (An arbitrary length of time was chosen.)
+#define ACCEPTABLE_EVENT_TIME_ON_TRANSPORT_THREAD  (2000)
+
 #if !defined(PJ_LINUX_KERNEL) || PJ_LINUX_KERNEL==0
     /*
      * Linux user mode
@@ -835,7 +839,7 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
       // As little work as possible should be carried out on the single transport
       // thread, so log a warning if the transport thread spends over
       // 2,000 microseconds handling an event.
-      if (time_to_handle_event > 2000) {
+      if (time_to_handle_event > ACCEPTABLE_EVENT_TIME_ON_TRANSPORT_THREAD) {
         PJ_LOG(2, (THIS_FILE, "The transport thread spent %d microseconds processing an event.", time_to_handle_event));
       }
 

--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -679,7 +679,8 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
     struct queue queue[PJ_IOQUEUE_MAX_EVENTS_IN_SINGLE_POLL];
     pj_timestamp t1, t2;
 
-    // Add timestamps to check each event doesn't take too long to handle.
+    // Add timestamps, which will be used to check how long each event takes to
+    // handle.
     pj_timestamp time_before_handling_event, time_after_handling_event;
     pj_uint32_t time_to_handle_event;
 

--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -807,9 +807,6 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
 
     PJ_RACE_ME(5);
 
-    PJ_LOG(1, (THIS_FILE, "Going through ioqueue_epoll.c"));
-
-
     /* Now process the events. */
     for (i=0; i<processed; ++i) {
       pj_get_timestamp(&time_before_handling_event);
@@ -834,13 +831,11 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
       // This time is in microseconds.
       time_to_handle_event = pj_elapsed_usec(&time_before_handling_event, &time_after_handling_event);
 
-      // If it has taken over 10,000 microseconds to handle an event then we are
-      // carrying out a blocking event on the transport thread, which we
-      // shouldn't do, so log a warning.
-      // Actually allow 11,000 microseconds for some leeway.
-      PJ_LOG(2, (THIS_FILE, "Time on transport thread: %d usec.", time_to_handle_event));
-      if (time_to_handle_event > 8000) {
-        PJ_LOG(2, (THIS_FILE, "A blocking task has been carried out on the transport thread."));
+      // As little work as possible should be carried out on the single transport
+      // thread, so log a warning if the transport thread spends over
+      // 2,000 microseconds handling an event.
+      if (time_to_handle_event > 2000) {
+        PJ_LOG(2, (THIS_FILE, "The transport thread spent %d microseconds processing an event.", time_to_handle_event));
       }
 
 #if PJ_IOQUEUE_HAS_SAFE_UNREG

--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -1,5 +1,5 @@
 /* $Id: timer.c 4359 2013-02-21 11:18:36Z bennylp $ */
-/* 
+/*
  * The PJLIB's timer heap is based (or more correctly, copied and modied)
  * from ACE library by Douglas C. Schmidt. ACE is an excellent OO framework
  * that implements many core patterns for concurrent communication software.
@@ -27,7 +27,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 #include <pj/timer.h>
 #include <pj/pool.h>
@@ -125,7 +125,7 @@ static void copy_node( pj_timer_heap_t *ht, int slot, pj_timer_entry *moved_node
 
     // Insert <moved_node> into its new location in the heap.
     ht->heap[slot] = moved_node;
-    
+
     // Update the corresponding slot in the parallel <timer_ids_> array.
     ht->timer_ids[moved_node->_timer_id] = slot;
 }
@@ -134,16 +134,16 @@ static pj_timer_id_t pop_freelist( pj_timer_heap_t *ht )
 {
     // We need to truncate this to <int> for backwards compatibility.
     pj_timer_id_t new_id = ht->timer_ids_freelist;
-    
+
     PJ_CHECK_STACK();
 
     // The freelist values in the <timer_ids_> are negative, so we need
     // to negate them to get the next freelist "pointer."
     ht->timer_ids_freelist =
 	-ht->timer_ids[ht->timer_ids_freelist];
-    
+
     return new_id;
-    
+
 }
 
 static void push_freelist (pj_timer_heap_t *ht, pj_timer_id_t old_id)
@@ -163,14 +163,14 @@ static void reheap_down(pj_timer_heap_t *ht, pj_timer_entry *moved_node,
     PJ_CHECK_STACK();
 
     // Restore the heap property after a deletion.
-    
+
     while (child < ht->cur_size)
     {
 	// Choose the smaller of the two children.
 	if (child + 1 < ht->cur_size
 	    && PJ_TIME_VAL_LT(ht->heap[child + 1]->_timer_value, ht->heap[child]->_timer_value))
 	    child++;
-	
+
 	// Perform a <copy> if the child has a larger timeout value than
 	// the <moved_node>.
 	if (PJ_TIME_VAL_LT(ht->heap[child]->_timer_value, moved_node->_timer_value))
@@ -183,7 +183,7 @@ static void reheap_down(pj_timer_heap_t *ht, pj_timer_entry *moved_node,
 	    // We've found our location in the heap.
 	    break;
     }
-    
+
     copy_node( ht, slot, moved_node);
 }
 
@@ -191,7 +191,7 @@ static void reheap_up( pj_timer_heap_t *ht, pj_timer_entry *moved_node,
 		       size_t slot, size_t parent)
 {
     // Restore the heap property after an insertion.
-    
+
     while (slot > 0)
     {
 	// If the parent node is greater than the <moved_node> we need
@@ -205,7 +205,7 @@ static void reheap_up( pj_timer_heap_t *ht, pj_timer_entry *moved_node,
 	else
 	    break;
     }
-    
+
     // Insert the new node into its proper resting place in the heap and
     // update the corresponding slot in the parallel <timer_ids> array.
     copy_node(ht, slot, moved_node);
@@ -215,38 +215,38 @@ static void reheap_up( pj_timer_heap_t *ht, pj_timer_entry *moved_node,
 static pj_timer_entry * remove_node( pj_timer_heap_t *ht, size_t slot)
 {
     pj_timer_entry *removed_node = ht->heap[slot];
-    
+
     // Return this timer id to the freelist.
     push_freelist( ht, removed_node->_timer_id );
-    
+
     // Decrement the size of the heap by one since we're removing the
     // "slot"th node.
     ht->cur_size--;
-    
+
     // Set the ID
     removed_node->_timer_id = -1;
 
     // Only try to reheapify if we're not deleting the last entry.
-    
+
     if (slot < ht->cur_size)
     {
 	int parent;
 	pj_timer_entry *moved_node = ht->heap[ht->cur_size];
-	
+
 	// Move the end node to the location being removed and update
 	// the corresponding slot in the parallel <timer_ids> array.
 	copy_node( ht, slot, moved_node);
-	
+
 	// If the <moved_node->time_value_> is great than or equal its
 	// parent it needs be moved down the heap.
 	parent = HEAP_PARENT (slot);
-	
+
 	if (PJ_TIME_VAL_GTE(moved_node->_timer_value, ht->heap[parent]->_timer_value))
 	    reheap_down( ht, moved_node, slot, HEAP_LEFT(slot));
 	else
 	    reheap_up( ht, moved_node, slot, parent);
     }
-    
+
     return removed_node;
 }
 
@@ -256,32 +256,32 @@ static void grow_heap(pj_timer_heap_t *ht)
     size_t new_size = ht->max_size * 2;
     pj_timer_id_t *new_timer_ids;
     pj_size_t i;
-    
+
     // First grow the heap itself.
-    
+
     pj_timer_entry **new_heap = 0;
-    
-    new_heap = (pj_timer_entry**) 
+
+    new_heap = (pj_timer_entry**)
     	       pj_pool_alloc(ht->pool, sizeof(pj_timer_entry*) * new_size);
     memcpy(new_heap, ht->heap, ht->max_size * sizeof(pj_timer_entry*));
     //delete [] this->heap_;
     ht->heap = new_heap;
-    
+
     // Grow the array of timer ids.
-    
+
     new_timer_ids = 0;
     new_timer_ids = (pj_timer_id_t*)
     		    pj_pool_alloc(ht->pool, new_size * sizeof(pj_timer_id_t));
-    
+
     memcpy( new_timer_ids, ht->timer_ids, ht->max_size * sizeof(pj_timer_id_t));
-    
+
     //delete [] timer_ids_;
     ht->timer_ids = new_timer_ids;
-    
+
     // And add the new elements to the end of the "freelist".
     for (i = ht->max_size; i < new_size; i++)
 	ht->timer_ids[i] = -((pj_timer_id_t) (i + 1));
-    
+
     ht->max_size = new_size;
 }
 
@@ -289,14 +289,14 @@ static void insert_node(pj_timer_heap_t *ht, pj_timer_entry *new_node)
 {
     if (ht->cur_size + 2 >= ht->max_size)
 	grow_heap(ht);
-    
+
     reheap_up( ht, new_node, ht->cur_size, HEAP_PARENT(ht->cur_size));
     ht->cur_size++;
 }
 
 
 static pj_status_t schedule_entry( pj_timer_heap_t *ht,
-				   pj_timer_entry *entry, 
+				   pj_timer_entry *entry,
 				   const pj_time_val *future_time )
 {
     if (ht->cur_size < ht->max_size)
@@ -313,8 +313,8 @@ static pj_status_t schedule_entry( pj_timer_heap_t *ht,
 }
 
 
-static int cancel( pj_timer_heap_t *ht, 
-		   pj_timer_entry *entry, 
+static int cancel( pj_timer_heap_t *ht,
+		   pj_timer_entry *entry,
 		   int dont_call)
 {
   long timer_node_slot;
@@ -353,7 +353,7 @@ static int cancel( pj_timer_heap_t *ht,
 PJ_DEF(pj_size_t) pj_timer_heap_mem_size(pj_size_t count)
 {
     return /* size of the timer heap itself: */
-           sizeof(pj_timer_heap_t) + 
+           sizeof(pj_timer_heap_t) +
            /* size of each entry: */
            (count+2) * (sizeof(pj_timer_entry*)+sizeof(pj_timer_id_t)) +
            /* lock, pool etc: */
@@ -509,7 +509,7 @@ static pj_status_t schedule_w_grp_lock(pj_timer_heap_t *ht,
 #endif
     pj_gettickcount(&expires);
     PJ_TIME_VAL_ADD(expires, *delay);
-    
+
     lock_timer_heap(ht);
     status = schedule_entry(ht, entry, &expires);
     if (status == PJ_SUCCESS) {
@@ -605,11 +605,16 @@ PJ_DEF(int) pj_timer_heap_cancel_if_active(pj_timer_heap_t *ht,
     return cancel_timer(ht, entry, PJ_TRUE, id_val);
 }
 
-PJ_DEF(unsigned) pj_timer_heap_poll( pj_timer_heap_t *ht, 
+PJ_DEF(unsigned) pj_timer_heap_poll( pj_timer_heap_t *ht,
                                      pj_time_val *next_delay )
 {
     pj_time_val now;
     unsigned count;
+
+    // Add timestamps, which will be used to check how long any callbacks take
+    // to be handled.
+    pj_timestamp time_before_handling_callback, time_after_handling_callback;
+    pj_uint32_t time_to_handle_callback;
 
     PJ_ASSERT_RETURN(ht, 0);
 
@@ -623,9 +628,9 @@ PJ_DEF(unsigned) pj_timer_heap_poll( pj_timer_heap_t *ht,
     count = 0;
     pj_gettickcount(&now);
 
-    while ( ht->cur_size && 
+    while ( ht->cur_size &&
 	    PJ_TIME_VAL_LTE(ht->heap[0]->_timer_value, now) &&
-            count < ht->max_entries_per_poll ) 
+            count < ht->max_entries_per_poll )
     {
 	pj_timer_entry *node = remove_node(ht, 0);
 	pj_grp_lock_t *grp_lock;
@@ -639,8 +644,24 @@ PJ_DEF(unsigned) pj_timer_heap_poll( pj_timer_heap_t *ht,
 
 	PJ_RACE_ME(5);
 
-	if (node->cb)
-	    (*node->cb)(ht, node);
+  if (node->cb)
+  {
+    pj_get_timestamp(&time_before_handling_callback);
+
+    (*node->cb)(ht, node);
+
+    pj_get_timestamp(&time_after_handling_callback);
+
+    // This time is in microseconds.
+    time_to_handle_callback = pj_elapsed_usec(&time_before_handling_callback, &time_after_handling_callback);
+
+    // As little work as possible should be carried out on the single transport
+    // thread, so log a warning if the transport thread spent over
+    // 1,000 microseconds handling this callback.
+    if (time_to_handle_callback > 1000) {
+      PJ_LOG(2, (THIS_FILE, "The transport thread spent %d microseconds processing a callback.", time_to_handle_callback));
+    }
+  }
 
 	if (grp_lock)
 	    pj_grp_lock_dec_ref(grp_lock);

--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -47,6 +47,9 @@
 
 #define DEFAULT_MAX_TIMED_OUT_PER_POLL  (64)
 
+// The length of time (in usecs) that it is acceptable to spend processing a
+// callback on the transport thread. (An arbitrary length of time was chosen.)
+#define ACCEPTABLE_CB_TIME_ON_TRANSPORT_THREAD  (1000)
 
 /**
  * The implementation of timer heap.
@@ -658,7 +661,7 @@ PJ_DEF(unsigned) pj_timer_heap_poll( pj_timer_heap_t *ht,
     // As little work as possible should be carried out on the single transport
     // thread, so log a warning if the transport thread spent over
     // 1,000 microseconds handling this callback.
-    if (time_to_handle_callback > 1000) {
+    if (time_to_handle_callback > ACCEPTABLE_CB_TIME_ON_TRANSPORT_THREAD) {
       PJ_LOG(2, (THIS_FILE, "The transport thread spent %d microseconds processing a callback.", time_to_handle_callback));
     }
   }


### PR DESCRIPTION
Some code has been added to pjsip to find blocking tasks that are being carried out on the transport thread, by logging a warning whenever the transport thread takes over X microseconds to handle an event/callback.

Placeholders for the threshold of 2,000 and 1,000 microseconds for logging the warnings have been put into this code, however I am currently looking into the longest times that it takes to handle an event/callback, so these numbers may be changed in the future.

The live tests passed when this code was included.

Here is an example of a log that showed up when the code was live tested, from handling an event:
`11-10-2017 11:27:17.689 UTC Warning pjsip:      ioq_epoll The transport thread spent 2087 microseconds processing an event.`

Here is an example of a log that showed up when the code was live tested, from handling a callback:
`11-10-2017 13:35:18.642 UTC Warning pjsip:        timer.c The transport thread spent 3772 microseconds processing a callback.`