### PR TITLE
Lower severity of "slow transport thread" log

### DIFF
--- a/pjlib/src/pj/ioqueue_epoll.c
+++ b/pjlib/src/pj/ioqueue_epoll.c
@@ -837,10 +837,9 @@ PJ_DEF(int) pj_ioqueue_poll( pj_ioqueue_t *ioqueue, const pj_time_val *timeout)
       time_to_handle_event = pj_elapsed_usec(&time_before_handling_event, &time_after_handling_event);
 
       // As little work as possible should be carried out on the single transport
-      // thread, so log a warning if the transport thread spends over
-      // 2,000 microseconds handling an event.
+      // thread, so log if the transport thread spends too long handling an event.
       if (time_to_handle_event > ACCEPTABLE_EVENT_TIME_ON_TRANSPORT_THREAD) {
-        PJ_LOG(2, (THIS_FILE, "The transport thread spent %d microseconds processing an event.", time_to_handle_event));
+        PJ_LOG(3, (THIS_FILE, "The transport thread spent %d microseconds processing an event.", time_to_handle_event));
       }
 
 #if PJ_IOQUEUE_HAS_SAFE_UNREG

--- a/pjlib/src/pj/timer.c
+++ b/pjlib/src/pj/timer.c
@@ -659,10 +659,10 @@ PJ_DEF(unsigned) pj_timer_heap_poll( pj_timer_heap_t *ht,
     time_to_handle_callback = pj_elapsed_usec(&time_before_handling_callback, &time_after_handling_callback);
 
     // As little work as possible should be carried out on the single transport
-    // thread, so log a warning if the transport thread spent over
-    // 1,000 microseconds handling this callback.
+    // thread, so log if the transport thread spent too long handling this
+    // callback.
     if (time_to_handle_callback > ACCEPTABLE_CB_TIME_ON_TRANSPORT_THREAD) {
-      PJ_LOG(2, (THIS_FILE, "The transport thread spent %d microseconds processing a callback.", time_to_handle_callback));
+      PJ_LOG(3, (THIS_FILE, "The transport thread spent %d microseconds processing a callback.", time_to_handle_callback));
     }
   }
 


### PR DESCRIPTION
The log for when the PJSIP transport thread takes to long to process a message or a callback is too spammy
as the thread occasionally needs to wait on a lock. Lower the severity so it isn't printed by default.