### PR TITLE
[Reviewer: KH1] Expose pjsip_generic_array_hdr_print

### DIFF
--- a/pjsip/include/pjsip/sip_msg.h
+++ b/pjsip/include/pjsip/sip_msg.h
@@ -1169,7 +1169,7 @@ pjsip_generic_array_hdr* pjsip_generic_array_hdr_shallow_clone( pj_pool_t *pool,
  *
  * @param hdr	      Header to clone.
  * @param buf	      The buffer.
- * @param size>       The size of the buffer.
+ * @param size	      The size of the buffer.
  *
  * @return	The size copied to buffer, or -1 if there's not enough space.
  */

--- a/pjsip/include/pjsip/sip_msg.h
+++ b/pjsip/include/pjsip/sip_msg.h
@@ -1165,6 +1165,18 @@ pjsip_generic_array_hdr* pjsip_generic_array_hdr_shallow_clone( pj_pool_t *pool,
 						 const pjsip_generic_array_hdr *hdr);
 
 /**
+ * Print a generic array header
+ *
+ * @param hdr	      Header to clone.
+ * @param buf	      The buffer.
+ * @param size>       The size of the buffer.
+ *
+ * @return	The size copied to buffer, or -1 if there's not enough space.
+ */
+int pjsip_generic_array_hdr_print( pjsip_generic_array_hdr *hdr,
+					  char *buf, pj_size_t size);
+
+/**
  * Initialize a preallocated memory with the header structure. This function
  * should only be called when application uses its own memory allocation to
  * allocate memory block for the specified header (e.g. in C++, when the

--- a/pjsip/src/pjsip/sip_msg.c
+++ b/pjsip/src/pjsip/sip_msg.c
@@ -917,8 +917,6 @@ int pjsip_delimited_array_hdr_print( pjsip_generic_array_hdr *hdr,
 /*
  * Generic array header.
  */
-static int pjsip_generic_array_hdr_print( pjsip_generic_array_hdr *hdr, char *buf, pj_size_t size);
-
 static pjsip_hdr_vptr generic_array_hdr_vptr =
 {
     (pjsip_hdr_clone_fptr) &pjsip_generic_array_hdr_clone,
@@ -951,7 +949,7 @@ PJ_DEF(pjsip_generic_array_hdr*) pjsip_generic_array_hdr_create( pj_pool_t *pool
 }
 
 
-static int pjsip_generic_array_hdr_print( pjsip_generic_array_hdr *hdr,
+int pjsip_generic_array_hdr_print( pjsip_generic_array_hdr *hdr,
 					  char *buf, pj_size_t size)
 {
     pj_str_t comma_delimiter = {", ", 2};


### PR DESCRIPTION
Moves a function into a header so that I can call it from sprout.