### PR TITLE
[Reviewer: KH1] Move definition of multipart_data struct to header

### DIFF
--- a/pjsip/include/pjsip/sip_multipart.h
+++ b/pjsip/include/pjsip/sip_multipart.h
@@ -59,6 +59,13 @@ typedef struct pjsip_multipart_part
 
 } pjsip_multipart_part;
 
+/* Type of "data" in multipart pjsip_msg_body */
+struct multipart_data
+{
+    pj_str_t	    	  boundary;
+    pjsip_multipart_part  part_head;
+};
+
 /**
  * Create an empty multipart body.
  *

--- a/pjsip/src/pjsip/sip_multipart.c
+++ b/pjsip/src/pjsip/sip_multipart.c
@@ -40,13 +40,6 @@
 
 extern pj_bool_t pjsip_use_compact_form;
 
-/* Type of "data" in multipart pjsip_msg_body */
-struct multipart_data
-{
-    pj_str_t	    	  boundary;
-    pjsip_multipart_part  part_head;
-};
-
 
 static int multipart_print_body(struct pjsip_msg_body *msg_body,
 			        char *buf, pj_size_t size)


### PR DESCRIPTION
Hi Krista,

Please could you review this small PR.

For the registration sender UTs that I'm adding, I want to check the multipart bodies of 3rd party registers.

To do that, I need access to the `multipart_data` struct in PJSIP. This PR moves the definition of that struct to a header file so I can access it from sprout.

To avoid managing submodule changes on the SDM branch, I want to merge this straight into master since it's such a small change. Once this is merged, I'll send through the Registration Sender changes.

Thanks,

Sathiyan