### PR TITLE
[Reviewer: RJW2] Fix overlapping memory addresses in pj_sockaddr_copy_addr

### DIFF
--- a/pjlib/src/pj/sock_common.c
+++ b/pjlib/src/pj/sock_common.c
@@ -874,8 +874,13 @@ PJ_DEF(pj_status_t) pj_gethostip(int af, pj_sockaddr *addr)
 		}
 
 		if (j == cand_cnt) {
-		    pj_sockaddr_copy_addr(&cand_addr[cand_cnt],
-					  &cand_addr[start_if+i]);
+		    // Check that the addresses we're copying are different -
+		    // if they're the same, we'll hit a valgrind error about
+		    // memcpy's source and destination overlapping.
+		    if (cand_cnt != start_if+i) {
+			pj_sockaddr_copy_addr(&cand_addr[cand_cnt],
+					      &cand_addr[start_if+i]);
+		    }
 		    cand_weight[cand_cnt] += WEIGHT_INTERFACE;
 		    ++cand_cnt;
 		}


### PR DESCRIPTION
This fixes the valgrind warning about memcpy's source and destination overlapping. It took me ages to understand this well enough to be sure this fix was safe, so here goes...

1. pj_gethostip returns the local IP
2. it does this by generating a list of candidates, scoring them then returning the best one
3. the first two candidates are the resolved local hostname and the interface for the default route, which occupy the first two of eight slots in cand_addr (or the first slot, if they're the same)
4. it then calls `pj_enum_ip_interface` to get more candidates - but these aren't really candidates yet. Let's call them 'maybe-candidates' as opposed to `full-candidates`. Everything in cand_addr from 0 to cand_count (exclusive) is a full-candidate; everything above that is a maybe-candidate.
5. It then loops over the maybe-candidates - if they are a duplicate of a full-candidate, it ignores them, otherwise it promotes them to a full-candidate (by copying them to cand_addr[cand_count] and incrementing cand_count).
6. The full-candidates are scored through some algorithm and the best one is returned.


With docker in non-privileged mode, cand_addr looked like:

1: 172.17.0.3 (maybe-candidate)
0: 172.17.0.3

The only maybe-candidate was the same as the hostname/default route IP, so didn't move to being a full candidate.

With docker in privileged mode, cand_addr looked like:

2: 172.17.0.2 (maybe candidate)
1: 172.19.0.1 (maybe candidate)
0: 172.17.0.2

Now, when we look at 172.19.0.1, we do want to promote it to a full candidate - so cand_addr[1] is now the top of the full candidates list and we copy it to there. But that's where it already is, so that's an overlapping memcpy so we get valgrind warnings.

This PR basically says "don't copy it if it's already there".